### PR TITLE
[Feat] 회복 루틴

### DIFF
--- a/lib/service/storage/storage_key.dart
+++ b/lib/service/storage/storage_key.dart
@@ -6,4 +6,7 @@ class StorageKey {
   // 주의 : bool 타입 저장 시, defaultValue가 false인 것이 자연스러운 네이밍을 사용합니다
   // 예 : isFirstLaunch가 아닌 isNotFirstLaunch가 되어야 초기값이 첫 설치가 됨
   static const isNotFirstLaunch = 'isNotFirstLaunch';
+
+  // 마지막으로 회복루틴을 사용한 날짜
+  static const lastRecoveryRoutineDate = 'lastRecoveryRoutineDate';
 }

--- a/lib/theme/planit_typos.dart
+++ b/lib/theme/planit_typos.dart
@@ -105,6 +105,15 @@ class PlanitTypos {
     fontFamily: 'Pretendard',
   );
 
+  static const TextStyle pretendardBold64 = TextStyle(
+    fontSize: 64,
+    fontWeight: FontWeight.w700,
+    height: 1.5,
+    letterSpacing: -1.28, // -0.02 * 64
+    leadingDistribution: TextLeadingDistribution.proportional,
+    fontFamily: 'Pretendard',
+  );
+
   static const TextStyle blackHansSansRegular48 = TextStyle(
     fontSize: 48,
     fontWeight: FontWeight.w400,

--- a/lib/ui/common/view/default_layout.dart
+++ b/lib/ui/common/view/default_layout.dart
@@ -9,6 +9,8 @@ class DefaultLayout extends StatelessWidget {
   final String? title;
   final Widget? bottomNavigationBar;
   final Widget? floatingActionButton;
+  final bool extendBodyBehindAppBar;
+  final Color? appBarColor;
 
   const DefaultLayout({
     super.key,
@@ -17,11 +19,15 @@ class DefaultLayout extends StatelessWidget {
     this.title,
     this.bottomNavigationBar,
     this.floatingActionButton,
+    this.extendBodyBehindAppBar = false,
+    this.appBarColor,
   });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      // Body와 AppBar가 겹치도록
+      extendBodyBehindAppBar: true,
       backgroundColor: backgroundColor ?? PlanitColors.white01,
       appBar: renderAppBar(),
       body: child,
@@ -36,7 +42,7 @@ class DefaultLayout extends StatelessWidget {
     } else {
       // TODO: AppBar 커스텀
       return AppBar(
-        backgroundColor: PlanitColors.white01,
+        backgroundColor: appBarColor ?? PlanitColors.white01,
         foregroundColor: PlanitColors.black01,
         elevation: 0,
         title: Text(

--- a/lib/ui/common/view/default_layout.dart
+++ b/lib/ui/common/view/default_layout.dart
@@ -27,7 +27,7 @@ class DefaultLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       // Body와 AppBar가 겹치도록
-      extendBodyBehindAppBar: true,
+      extendBodyBehindAppBar: extendBodyBehindAppBar,
       backgroundColor: backgroundColor ?? PlanitColors.white01,
       appBar: renderAppBar(),
       body: child,

--- a/lib/ui/main/component/recovery_routine_banner.dart
+++ b/lib/ui/main/component/recovery_routine_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:planit/ui/recovery/recovery_intro_view.dart';
 
 import '../../../theme/planit_colors.dart';
 import '../../../theme/planit_typos.dart';
@@ -13,35 +14,42 @@ class RecoveryRoutineBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: PlanitColors.green,
-        borderRadius: BorderRadiusGeometry.circular(12.0),
+    return GestureDetector(
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => RecoveryIntroView(),
+        ),
       ),
-      padding: EdgeInsetsGeometry.symmetric(
-        horizontal: 20.0,
-        vertical: 16.0,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          PlanitText(
-            '할 일 시작이 어려우신가요?',
-            style: PlanitTypos.body2.copyWith(
-              color: PlanitColors.white01,
-            ),
-          ),
-          IconButton(
-            onPressed: () {},
-            icon: SvgPicture.asset(
-              Assets.x,
-              colorFilter: ColorFilter.mode(
-                PlanitColors.white01,
-                BlendMode.srcIn,
+      child: Container(
+        decoration: BoxDecoration(
+          color: PlanitColors.green,
+          borderRadius: BorderRadiusGeometry.circular(12.0),
+        ),
+        padding: EdgeInsetsGeometry.symmetric(
+          horizontal: 20.0,
+          vertical: 16.0,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            PlanitText(
+              '할 일 시작이 어려우신가요?',
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.white01,
               ),
             ),
-          ),
-        ],
+            IconButton(
+              onPressed: () {},
+              icon: SvgPicture.asset(
+                Assets.x,
+                colorFilter: ColorFilter.mode(
+                  PlanitColors.white01,
+                  BlendMode.srcIn,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -68,10 +68,10 @@ class MainView extends HookConsumerWidget {
               ),
               RouteSwitchBanner(
                 type: state.routeType,
-                onLeftArrowPressed: () => viewModel.switchToLeft(
+                onLeftArrowPressed: () => viewModel.switchRoute(
                   currentType: state.routeType,
                 ),
-                onRightArrowPressed: () => viewModel.switchToRight(
+                onRightArrowPressed: () => viewModel.switchRoute(
                   currentType: state.routeType,
                 ),
               ),

--- a/lib/ui/recovery/component/recovery_bg.dart
+++ b/lib/ui/recovery/component/recovery_bg.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/planit_colors.dart';
+
+class RecoveryBg extends StatelessWidget {
+  final Widget child;
+
+  const RecoveryBg({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            PlanitColors.gradient1,
+            PlanitColors.gradient2,
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/component/recovery_timer.dart
+++ b/lib/ui/recovery/component/recovery_timer.dart
@@ -1,0 +1,101 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../../../theme/planit_colors.dart';
+import '../../../theme/planit_typos.dart';
+import '../../common/comopnent/planit_text.dart';
+
+class RecoveryTimer extends StatelessWidget {
+  final Animation<double> animation;
+  final double radius;
+  final int remainSeconds;
+
+  const RecoveryTimer({
+    super.key,
+    required this.animation,
+    required this.radius,
+    required this.remainSeconds,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // 연두색 원은 아래에 두고 애니메이션 적용된 Paniter가 위에 쌓이도록
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        CircleAvatar(
+          backgroundColor: Color(0xFFF1FFDB),
+          radius: radius,
+          child: PlanitText(
+            _formatTime(remainSeconds),
+            style: PlanitTypos.pretendardBold64.copyWith(
+              color: PlanitColors.green,
+            ),
+          ),
+        ),
+        AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) => CustomPaint(
+            size: Size(radius * 2, radius * 2),
+            painter: TimerPainter(
+              progress: animation.value,
+              radius: radius,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// Timer 위에 움직이는 선만 CustomPaint로 구현
+class TimerPainter extends CustomPainter {
+  final double progress;
+  final double radius;
+
+  TimerPainter({
+    required this.progress,
+    required this.radius,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // 원 중심
+    final center = Offset(size.width / 2, size.height / 2);
+    // 12시 방향에서 시작
+    const startingAngle = -0.5 * pi;
+
+    final redArcRect = Rect.fromCircle(center: center, radius: radius);
+
+    // 스타일 설정
+    final redArcPaint = Paint()
+      ..color = PlanitColors.green
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 16;
+
+    canvas.drawArc(
+      redArcRect,
+      startingAngle,
+      progress * 2 * pi,
+      false,
+      redArcPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return true;
+  }
+}
+
+String _formatTime(int seconds) {
+  int minutes = seconds ~/ 60;
+  int remainingSeconds = seconds % 60;
+
+  // 초가 한 자리일 때 앞에 0 추가
+  String secondsStr = remainingSeconds.toString().padLeft(2, '0');
+
+  return '$minutes:$secondsStr';
+}

--- a/lib/ui/recovery/recovery_complete_view.dart
+++ b/lib/ui/recovery/recovery_complete_view.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/theme/planit_typos.dart';
+import 'package:planit/ui/common/comopnent/planit_button.dart';
+import 'package:planit/ui/common/comopnent/planit_text.dart';
+import 'package:planit/ui/common/const/planit_button_style.dart';
+import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
+
+import '../common/assets.dart';
+
+class RecoveryCompleteView extends StatelessWidget {
+  const RecoveryCompleteView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final Size deviceSize = MediaQuery.of(context).size;
+    return DefaultLayout(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Padding(
+            padding: EdgeInsetsGeometry.only(bottom: 120.0),
+            child: SvgPicture.asset(
+              Assets.mascotRestarting,
+              width: deviceSize.width,
+            ),
+          ),
+          Column(
+            children: [
+              Spacer(),
+              PlanitText(
+                '오늘도 첫 걸음을 떼었어요',
+                style: PlanitTypos.title1.copyWith(
+                  color: PlanitColors.black01,
+                ),
+              ),
+              // 이미지 보이도록 공간 넓게 할당
+              Spacer(flex: 3),
+              PlanitText(
+                '이제 해야 할 일로 부드럽게 연결해볼게요.\n같이 해볼까요? 😄',
+                textAlign: TextAlign.center,
+                style: PlanitTypos.body2.copyWith(
+                  color: PlanitColors.black02,
+                ),
+              ),
+              Spacer(),
+              Container(
+                margin: EdgeInsetsGeometry.only(
+                  left: 20.0,
+                  right: 20.0,
+                  bottom: 40.0,
+                ),
+                width: double.infinity,
+                child: PlanitButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => RootTab(),
+                    ),
+                  ),
+                  buttonColor: PlanitButtonColor.black,
+                  buttonSize: PlanitButtonSize.large,
+                  label: '오늘도 한 발짝 나아가기',
+                ),
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/recovery_complete_view.dart
+++ b/lib/ui/recovery/recovery_complete_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:planit/service/storage/planit_storage_service.dart';
+import 'package:planit/service/storage/storage_key.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
@@ -10,11 +13,13 @@ import 'package:planit/ui/common/view/root_tab.dart';
 
 import '../common/assets.dart';
 
-class RecoveryCompleteView extends StatelessWidget {
+class RecoveryCompleteView extends ConsumerWidget {
   const RecoveryCompleteView({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final PlanitStorageService service = ref.read(planitStorageServiceProvider);
+
     final Size deviceSize = MediaQuery.of(context).size;
     return DefaultLayout(
       child: Stack(
@@ -54,11 +59,18 @@ class RecoveryCompleteView extends StatelessWidget {
                 ),
                 width: double.infinity,
                 child: PlanitButton(
-                  onPressed: () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => RootTab(),
-                    ),
-                  ),
+                  onPressed: () {
+                    // 회복루틴 종료 시 오늘 날짜 저장
+                    service.setString(
+                      key: StorageKey.lastRecoveryRoutineDate,
+                      value: DateTime.now().toString(),
+                    );
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => RootTab(),
+                      ),
+                    );
+                  },
                   buttonColor: PlanitButtonColor.black,
                   buttonSize: PlanitButtonSize.large,
                   label: '오늘도 한 발짝 나아가기',

--- a/lib/ui/recovery/recovery_deep_breath_view.dart
+++ b/lib/ui/recovery/recovery_deep_breath_view.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/recovery/recovery_small_action_view.dart';
+
+import '../../theme/planit_typos.dart';
+import '../common/comopnent/planit_button.dart';
+import '../common/comopnent/planit_text.dart';
+import '../common/const/planit_button_style.dart';
+import 'component/recovery_bg.dart';
+import 'component/recovery_timer.dart';
+
+class RecoveryDeepBreathView extends StatefulWidget {
+  const RecoveryDeepBreathView({super.key});
+
+  @override
+  State<RecoveryDeepBreathView> createState() => _RecoveryDeepBreathViewState();
+}
+
+class _RecoveryDeepBreathViewState extends State<RecoveryDeepBreathView>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animationController = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 60),
+  )..forward();
+
+  late final Animation<double> _animation = Tween(begin: 0.0, end: 1.0).animate(
+    // 일정한 속도로 원을 그리도록
+    CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.linear,
+    ),
+  );
+
+  int _remainSeconds = 60;
+
+  @override
+  void initState() {
+    super.initState();
+    // 애니메이션 진행 상태 리스너
+    _animationController.addListener(() {
+      setState(() {
+        // 매초 남은 시간 갱신
+        _remainSeconds = (60 * (1 - _animationController.value)).round();
+      });
+    });
+
+    // 애니메이션 완료 리스너
+    _animationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        // TODO: 버튼 활성화
+      }
+    });
+
+    // 애니메이션 시작
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 좌우 패딩 40만 두고 화면 채우도록
+    // 디바이스 height이 작다면 크기 더 작아지도록
+    final Size deviceSize = MediaQuery.of(context).size;
+    final double radius =
+        deviceSize.height < 700 ? 120 : (deviceSize.width - 80.0) / 2;
+
+    return DefaultLayout(
+      title: '회복 루틴',
+      appBarColor: PlanitColors.transparent,
+      extendBodyBehindAppBar: true,
+      child: RecoveryBg(
+        child: Padding(
+          padding: EdgeInsetsGeometry.only(
+            left: 20.0,
+            right: 20.0,
+            top: 20.0,
+            bottom: 40.0,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              PlanitText(
+                '우선 1분 동안\n가볍게 심호흡을 해봐요',
+                textAlign: TextAlign.center,
+                style: PlanitTypos.title1.copyWith(
+                  color: PlanitColors.black01,
+                ),
+              ),
+              Spacer(),
+              RecoveryTimer(
+                animation: _animation,
+                radius: radius,
+                remainSeconds: _remainSeconds,
+              ),
+              Spacer(),
+              PlanitText(
+                '생각을 잠시 멈추고 숨쉬는 것에만 집중하며,\n해야할 일을 받아들여요',
+                textAlign: TextAlign.center,
+                style: PlanitTypos.body2.copyWith(
+                  color: PlanitColors.black02,
+                ),
+              ),
+              Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: PlanitButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => RecoverySmallActionView(),
+                    ),
+                  ),
+                  buttonColor: PlanitButtonColor.black,
+                  buttonSize: PlanitButtonSize.large,
+                  label: '다음',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/recovery_description_view.dart
+++ b/lib/ui/recovery/recovery_description_view.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:planit/ui/common/assets.dart';
+import 'package:planit/ui/recovery/recovery_deep_breath_view.dart';
+
+import '../../theme/planit_colors.dart';
+import '../../theme/planit_typos.dart';
+import '../common/comopnent/planit_button.dart';
+import '../common/comopnent/planit_text.dart';
+import '../common/const/planit_button_style.dart';
+import '../common/view/default_layout.dart';
+
+class RecoveryDescriptionView extends StatelessWidget {
+  const RecoveryDescriptionView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultLayout(
+      title: '회복 루틴',
+      child: Padding(
+        padding: EdgeInsetsGeometry.only(
+          left: 20.0,
+          right: 20.0,
+          top: 20.0,
+          bottom: 40.0,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            PlanitText(
+              '다시 시작할 힘을\n만드는 작은 루틴이에요',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.title1.copyWith(
+                color: PlanitColors.black01,
+              ),
+            ),
+            Spacer(),
+            // 회복 루틴 단계 설정
+            Column(
+              spacing: 12.0,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                _TextBox(
+                  title: '숨 고르기',
+                  time: '1분',
+                ),
+                SvgPicture.asset(Assets.chevronDown),
+                _TextBox(
+                  title: '작은 행동',
+                  time: '2분',
+                ),
+              ],
+            ),
+            Spacer(),
+            PlanitText(
+              '3분 동안 따라만 와주세요.\n해야 할 일을 피하지 않게,\n당신을 부드럽게 이끌어드릴게요.',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.black02,
+              ),
+            ),
+            Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: PlanitButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => RecoveryDeepBreathView(),
+                  ),
+                ),
+                buttonColor: PlanitButtonColor.black,
+                buttonSize: PlanitButtonSize.large,
+                label: '시작하기',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TextBox extends StatelessWidget {
+  final String title;
+  final String time;
+
+  const _TextBox({
+    required this.title,
+    required this.time,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsetsGeometry.all(20.0),
+      decoration: BoxDecoration(
+        color: PlanitColors.white02,
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          PlanitText(
+            title,
+            style: PlanitTypos.title3.copyWith(
+              color: PlanitColors.black01,
+            ),
+          ),
+          PlanitText(
+            time,
+            style: PlanitTypos.title3.copyWith(
+              color: PlanitColors.black01,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/recovery_intro_view.dart
+++ b/lib/ui/recovery/recovery_intro_view.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/theme/planit_typos.dart';
+import 'package:planit/ui/common/assets.dart';
+import 'package:planit/ui/common/comopnent/planit_button.dart';
+import 'package:planit/ui/common/comopnent/planit_text.dart';
+import 'package:planit/ui/common/const/planit_button_style.dart';
+import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/recovery/recovery_stop_phone_view.dart';
+
+class RecoveryIntroView extends StatelessWidget {
+  const RecoveryIntroView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultLayout(
+      child: Padding(
+        padding: EdgeInsetsGeometry.only(
+          left: 20.0,
+          right: 20.0,
+          bottom: 40.0,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Spacer(flex: 2),
+            PlanitText(
+              '할 일 시작이\n어려우신가요?',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.title1.copyWith(
+                color: PlanitColors.black01,
+              ),
+            ),
+            Spacer(),
+            SvgPicture.asset(Assets.mascotThinking),
+            Spacer(),
+            PlanitText(
+              '그럴 땐 억지로 밀어붙이지 말고,\n가볍게 몸과 마음부터 깨워볼까요?',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.black02,
+              ),
+            ),
+            Spacer(),
+            // Buttons
+            Column(
+              spacing: 20.0,
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  child: PlanitButton(
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => RecoveryStopPhoneView(),
+                      ),
+                    ),
+                    buttonColor: PlanitButtonColor.black,
+                    buttonSize: PlanitButtonSize.large,
+                    label: '회복 루틴 시작',
+                  ),
+                ),
+                SizedBox(
+                  width: double.infinity,
+                  child: PlanitButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    buttonColor: PlanitButtonColor.white,
+                    buttonSize: PlanitButtonSize.large,
+                    label: '닫기',
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/recovery_small_action_view.dart
+++ b/lib/ui/recovery/recovery_small_action_view.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:planit/ui/recovery/component/recovery_bg.dart';
+import 'package:planit/ui/recovery/recovery_complete_view.dart';
+
+import '../../theme/planit_colors.dart';
+import '../../theme/planit_typos.dart';
+import '../common/comopnent/planit_text.dart';
+import '../common/view/default_layout.dart';
+import 'component/recovery_timer.dart';
+
+class RecoverySmallActionView extends StatefulWidget {
+  const RecoverySmallActionView({super.key});
+
+  @override
+  State<RecoverySmallActionView> createState() =>
+      _RecoverySmallActionViewState();
+}
+
+class _RecoverySmallActionViewState extends State<RecoverySmallActionView>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animationController = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 120),
+  )..forward();
+
+  late final Animation<double> _animation = Tween(begin: 0.0, end: 1.0).animate(
+    // 일정한 속도로 원을 그리도록
+    CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.linear,
+    ),
+  );
+
+  int _remainSeconds = 120;
+
+  @override
+  void initState() {
+    super.initState();
+    // 애니메이션 진행 상태 리스너
+    _animationController.addListener(() {
+      setState(() {
+        // 매초 남은 시간 갱신
+        _remainSeconds = (120 * (1 - _animationController.value)).round();
+      });
+    });
+
+    // 애니메이션 완료 리스너
+    _animationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => RecoveryCompleteView(),
+          ),
+        );
+      }
+    });
+
+    // 애니메이션 시작
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 좌우 패딩 40만 두고 화면 채우도록
+    // 디바이스 height이 작다면 크기 더 작아지도록
+    final Size deviceSize = MediaQuery.of(context).size;
+    final double radius =
+    deviceSize.height < 700 ? 120 : (deviceSize.width - 80.0) / 2;
+
+    return DefaultLayout(
+      title: '회복 루틴',
+      appBarColor: PlanitColors.transparent,
+      extendBodyBehindAppBar: true,
+      child: RecoveryBg(
+        child: Padding(
+          padding: EdgeInsetsGeometry.only(
+            left: 20.0,
+            right: 20.0,
+            top: 20.0,
+            bottom: 40.0,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              PlanitText(
+                '지금 할 수 있는\n가장 작은 행동 하나만 해보세요',
+                textAlign: TextAlign.center,
+                style: PlanitTypos.title1.copyWith(
+                  color: PlanitColors.black01,
+                ),
+              ),
+              Spacer(),
+              RecoveryTimer(
+                animation: _animation,
+                radius: radius,
+                remainSeconds: _remainSeconds,
+              ),
+              Spacer(),
+              Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Color(0xFFF1FFDB),
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                padding: EdgeInsetsGeometry.symmetric(
+                  vertical: 24.0,
+                  horizontal: 20.0,
+                ),
+                child: Column(
+                  spacing: 12.0,
+                  children: [
+                    PlanitText(
+                      '예시',
+                      style: PlanitTypos.title3.copyWith(
+                        color: PlanitColors.black01,
+                      ),
+                    ),
+                    PlanitText(
+                      '💧 물 한 잔 마시기\n🤸 가볍게 스트레칭 하기\n🌬️ 창문 열기\n🚶 자리에서 일어나기',
+                      style: PlanitTypos.body2.copyWith(
+                        color: PlanitColors.black02,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Spacer(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/recovery/recovery_small_action_view.dart
+++ b/lib/ui/recovery/recovery_small_action_view.dart
@@ -71,9 +71,17 @@ class _RecoverySmallActionViewState extends State<RecoverySmallActionView>
     // 디바이스 height이 작다면 크기 더 작아지도록
     final Size deviceSize = MediaQuery.of(context).size;
     final double radius =
-    deviceSize.height < 700 ? 120 : (deviceSize.width - 80.0) / 2;
+        deviceSize.height < 700 ? 120 : (deviceSize.width - 80.0) / 2;
 
     return DefaultLayout(
+      // 테스트용 건너뛰기 버튼
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => RecoveryCompleteView(),
+          ),
+        ),
+      ),
       title: '회복 루틴',
       appBarColor: PlanitColors.transparent,
       extendBodyBehindAppBar: true,

--- a/lib/ui/recovery/recovery_stop_phone_view.dart
+++ b/lib/ui/recovery/recovery_stop_phone_view.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:planit/ui/recovery/recovery_description_view.dart';
+
+import '../../theme/planit_colors.dart';
+import '../../theme/planit_typos.dart';
+import '../common/assets.dart';
+import '../common/comopnent/planit_button.dart';
+import '../common/comopnent/planit_text.dart';
+import '../common/const/planit_button_style.dart';
+import '../common/view/default_layout.dart';
+
+class RecoveryStopPhoneView extends StatelessWidget {
+  const RecoveryStopPhoneView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultLayout(
+      title: '회복 루틴',
+      child: Padding(
+        padding: EdgeInsetsGeometry.only(
+          left: 20.0,
+          right: 20.0,
+          top: 20.0,
+          bottom: 40.0,
+        ),
+        child: Column(
+          children: [
+            PlanitText(
+              '우선,\n화면에서 눈을 떼볼게요',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.title1.copyWith(
+                color: PlanitColors.black01,
+              ),
+            ),
+            Spacer(),
+            SvgPicture.asset(Assets.imgRecoveryRoutinePhone),
+            Spacer(),
+            PlanitText(
+              '계속 폰을 들여다보면\n현실과의 감각이 조금씩 멀어져요.\n지금은 내 몸과 마음에 잠시 집중할 시간이에요.',
+              textAlign: TextAlign.center,
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.black02,
+              ),
+            ),
+            Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: PlanitButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => RecoveryDescriptionView(),
+                  ),
+                ),
+                buttonColor: PlanitButtonColor.black,
+                buttonSize: PlanitButtonSize.large,
+                label: '다음',
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 눈물의 회복 루틴을 구현했습니다
- 회복 루틴 배너가 일 최대 1회만 노출되도록, 회복 루틴 완료 시 그날 날짜를 로컬에 저장합니다
   - 메인 화면 초기화 시 마지막 회복 루틴 사용일과 오늘 날짜를 비교해, 사용 당일에는 노출되지 않도록 합니다
- **개선 필요한 부분**
   - 회복 루틴 배너의 X 클릭 시 안 뜨게 처리
   - 타이머 애니메이션 사라지도록.....생기게 말고.................

https://github.com/user-attachments/assets/1021158b-e9d3-469d-8759-c4430be2310d


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 눈물이 납니다 타이머 시간 줄어들면 초록링이 그려지게 만들었는데 사라져야되네요 애니메이션을 반대로 만들었네요 너무 슬픕니다 나중에 고칠게요.......................................................................
