### PR TITLE
[Feat] 메인 (거의) 완성

### DIFF
--- a/lib/core/api_response.dart
+++ b/lib/core/api_response.dart
@@ -1,0 +1,25 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'api_response.g.dart';
+
+// API 응답 구조
+@JsonSerializable(genericArgumentFactories: true)
+class ApiResponse<T> {
+  final bool isSuccess;
+  final String code;
+  final String message;
+  final T data;
+  final bool success;
+
+  const ApiResponse({
+    required this.isSuccess,
+    required this.code,
+    required this.message,
+    required this.data,
+    required this.success,
+  });
+
+  factory ApiResponse.fromJson(
+      Map<String, dynamic> json, T Function(Object? json) fromjsonT) =>
+      _$ApiResponseFromJson(json, fromjsonT);
+}

--- a/lib/core/api_response.g.dart
+++ b/lib/core/api_response.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ApiResponse<T> _$ApiResponseFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(Object? json) fromJsonT,
+) =>
+    ApiResponse<T>(
+      isSuccess: json['isSuccess'] as bool,
+      code: json['code'] as String,
+      message: json['message'] as String,
+      data: fromJsonT(json['data']),
+      success: json['success'] as bool,
+    );
+
+Map<String, dynamic> _$ApiResponseToJson<T>(
+  ApiResponse<T> instance,
+  Object? Function(T value) toJsonT,
+) =>
+    <String, dynamic>{
+      'isSuccess': instance.isSuccess,
+      'code': instance.code,
+      'message': instance.message,
+      'data': toJsonT(instance.data),
+      'success': instance.success,
+    };

--- a/lib/core/error_message.dart
+++ b/lib/core/error_message.dart
@@ -1,0 +1,1 @@
+const String networkErrorMsg = '일시적인 오류가 발생했어요.\n문제가 지속될 경우 고객센터에 문의해주세요.';

--- a/lib/data_source/main/main_data_source.dart
+++ b/lib/data_source/main/main_data_source.dart
@@ -15,7 +15,7 @@ final Provider<MainDataSource> mainDataSourceProvider =
 
 @RestApi()
 abstract class MainDataSource {
-  factory MainDataSource(Dio dio) = _PlanDataSource;
+  factory MainDataSource(Dio dio) = _MainDataSource;
 
   @GET('/planit/plans/today')
   Future<ApiResponse<TodayPlanListResponseBody>> getTodayTasks();

--- a/lib/data_source/main/main_data_source.dart
+++ b/lib/data_source/main/main_data_source.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planit/data_source/main/reponse_body/today_tasks_response_body.dart';
+import 'package:planit/service/network/dio_service.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../../core/api_response.dart';
+
+part 'main_data_source.g.dart';
+
+final Provider<MainDataSource> mainDataSourceProvider =
+    Provider<MainDataSource>(
+  (ref) => MainDataSource(ref.read(dioServiceProvider)),
+);
+
+@RestApi()
+abstract class MainDataSource {
+  factory MainDataSource(Dio dio) = _PlanDataSource;
+
+  @GET('/planit/plans/today')
+  Future<ApiResponse<TodayPlanListResponseBody>> getTodayTasks();
+
+  @POST('/planit/tasks/{taskId}/complete')
+  Future<void> completeTask({
+    @Path('taskId') required int taskId,
+  });
+}

--- a/lib/data_source/main/main_data_source.g.dart
+++ b/lib/data_source/main/main_data_source.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'main_data_source.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _PlanDataSource implements MainDataSource {
+  _PlanDataSource(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<ApiResponse<TodayPlanListResponseBody>> getTodayTasks() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<ApiResponse<TodayPlanListResponseBody>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/planit/plans/today',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiResponse<TodayPlanListResponseBody> _value;
+    try {
+      _value = ApiResponse<TodayPlanListResponseBody>.fromJson(
+        _result.data!,
+        (json) =>
+            TodayPlanListResponseBody.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> completeTask({required int taskId}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/planit/tasks/${taskId}/complete',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/data_source/main/main_data_source.g.dart
+++ b/lib/data_source/main/main_data_source.g.dart
@@ -8,8 +8,8 @@ part of 'main_data_source.dart';
 
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
-class _PlanDataSource implements MainDataSource {
-  _PlanDataSource(this._dio, {this.baseUrl, this.errorLogger});
+class _MainDataSource implements MainDataSource {
+  _MainDataSource(this._dio, {this.baseUrl, this.errorLogger});
 
   final Dio _dio;
 

--- a/lib/data_source/main/reponse_body/today_tasks_response_body.dart
+++ b/lib/data_source/main/reponse_body/today_tasks_response_body.dart
@@ -1,0 +1,58 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'today_tasks_response_body.g.dart';
+
+@JsonSerializable()
+class TodayPlanListResponseBody {
+  final String todayDate;
+  final String dayOfWeek;
+  final List<TodayPlanResponseBody> slowPlans;
+  final List<TodayPlanResponseBody> passionatePlans;
+
+  const TodayPlanListResponseBody({
+    required this.todayDate,
+    required this.dayOfWeek,
+    required this.slowPlans,
+    required this.passionatePlans,
+  });
+
+  factory TodayPlanListResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$TodayPlanListResponseBodyFromJson(json);
+}
+
+@JsonSerializable()
+class TodayPlanResponseBody {
+  final int planId;
+  final String title;
+  final List<TaskStatusResponseBody> tasks;
+  @JsonKey(name: 'dday')
+  final String dDay;
+
+  TodayPlanResponseBody({
+    required this.planId,
+    required this.title,
+    required this.tasks,
+    required this.dDay,
+  });
+
+  factory TodayPlanResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$TodayPlanResponseBodyFromJson(json);
+}
+
+@JsonSerializable()
+class TaskStatusResponseBody {
+  final int taskId;
+  final String title;
+  final String routineTime;
+  final bool isCompleted;
+
+  TaskStatusResponseBody({
+    required this.taskId,
+    required this.title,
+    required this.routineTime,
+    required this.isCompleted,
+  });
+
+  factory TaskStatusResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$TaskStatusResponseBodyFromJson(json);
+}

--- a/lib/data_source/main/reponse_body/today_tasks_response_body.g.dart
+++ b/lib/data_source/main/reponse_body/today_tasks_response_body.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'today_tasks_response_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TodayPlanListResponseBody _$TodayPlanListResponseBodyFromJson(
+        Map<String, dynamic> json) =>
+    TodayPlanListResponseBody(
+      todayDate: json['todayDate'] as String,
+      dayOfWeek: json['dayOfWeek'] as String,
+      slowPlans: (json['slowPlans'] as List<dynamic>)
+          .map((e) => TodayPlanResponseBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      passionatePlans: (json['passionatePlans'] as List<dynamic>)
+          .map((e) => TodayPlanResponseBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$TodayPlanListResponseBodyToJson(
+        TodayPlanListResponseBody instance) =>
+    <String, dynamic>{
+      'todayDate': instance.todayDate,
+      'dayOfWeek': instance.dayOfWeek,
+      'slowPlans': instance.slowPlans,
+      'passionatePlans': instance.passionatePlans,
+    };
+
+TodayPlanResponseBody _$TodayPlanResponseBodyFromJson(
+        Map<String, dynamic> json) =>
+    TodayPlanResponseBody(
+      planId: (json['planId'] as num).toInt(),
+      title: json['title'] as String,
+      tasks: (json['tasks'] as List<dynamic>)
+          .map(
+              (e) => TaskStatusResponseBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      dDay: json['dday'] as String,
+    );
+
+Map<String, dynamic> _$TodayPlanResponseBodyToJson(
+        TodayPlanResponseBody instance) =>
+    <String, dynamic>{
+      'planId': instance.planId,
+      'title': instance.title,
+      'tasks': instance.tasks,
+      'dday': instance.dDay,
+    };
+
+TaskStatusResponseBody _$TaskStatusResponseBodyFromJson(
+        Map<String, dynamic> json) =>
+    TaskStatusResponseBody(
+      taskId: (json['taskId'] as num).toInt(),
+      title: json['title'] as String,
+      routineTime: json['routineTime'] as String,
+      isCompleted: json['isCompleted'] as bool,
+    );
+
+Map<String, dynamic> _$TaskStatusResponseBodyToJson(
+        TaskStatusResponseBody instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'title': instance.title,
+      'routineTime': instance.routineTime,
+      'isCompleted': instance.isCompleted,
+    };

--- a/lib/repository/main/main_repository.dart
+++ b/lib/repository/main/main_repository.dart
@@ -1,75 +1,54 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planit/core/api_response.dart';
 import 'package:planit/core/repository_result.dart';
+import 'package:planit/data_source/main/main_data_source.dart';
 import 'package:planit/repository/main/model/main_plan_model.dart';
-import 'package:planit/ui/main/component/task_widget.dart';
+
+import '../../core/error_message.dart';
+import '../../data_source/main/reponse_body/today_tasks_response_body.dart';
 
 final AutoDisposeProvider<MainRepository> mainRepositoryProvider =
     Provider.autoDispose<MainRepository>(
-  (ref) => MainRepository(),
+  (ref) => MainRepository(
+    mainDataSource: ref.read(mainDataSourceProvider),
+  ),
 );
 
 class MainRepository {
-  const MainRepository();
+  final MainDataSource _mainDataSource;
 
-  Future<RepositoryResult<List<MainPlanModel>>> getMainPlanList() async {
-    // API 구현이 안 되어 있어, 임의 데이터 반환
-    await Future.delayed(Duration(seconds: 1));
+  const MainRepository({
+    required MainDataSource mainDataSource,
+  }) : _mainDataSource = mainDataSource;
 
-    return SuccessRepositoryResult(
-      data: [
-        MainPlanModel(
-          planTitle: '목표를 가운데에 놓고 스위치 목표를 가운데에 놓고 스위치',
-          tasks: [
-            TempTaskModel(
-              isCompleted: true,
-              task: '목표를 가운데에 놓고 스위치',
-            ),
-            TempTaskModel(
-              isCompleted: true,
-              task: '목표를 가운데에 놓고 스위치',
-            ),
-            TempTaskModel(
-              isCompleted: false,
-              task: '목표를 가운데에 놓고 스위치 목표를 가운데에 놓고 스위치 목표를 가운데에 놓고 스위치',
-            ),
-          ],
-          dDay: 32,
-        ),
-        MainPlanModel(
-          planTitle: '스파이에어 띵곡 모음',
-          tasks: [
-            TempTaskModel(
-              isCompleted: false,
-              task: '마이 월드',
-            ),
-            TempTaskModel(
-              isCompleted: false,
-              task: '라이어',
-            ),
-            TempTaskModel(
-              isCompleted: true,
-              task: '사무라이 하트',
-            ),
-            TempTaskModel(
-              isCompleted: false,
-              task: '비 그친 뒤 피어나는 꽃',
-            ),
-            TempTaskModel(
-              isCompleted: true,
-              task: '라스트 모멘트',
-            ),
-            TempTaskModel(
-              isCompleted: true,
-              task: '감정불화',
-            ),
-            TempTaskModel(
-              isCompleted: true,
-              task: '웬디 이츠 유',
-            ),
-          ],
-        ),
-      ],
-      // data: []
-    );
+  Future<RepositoryResult<TodayPlanListModel>> getMainPlanList() async {
+    try {
+      final ApiResponse<TodayPlanListResponseBody> result =
+          await _mainDataSource.getTodayTasks();
+      final TodayPlanListModel data = TodayPlanListModel.fromResponse(
+        result.data,
+      );
+      return SuccessRepositoryResult<TodayPlanListModel>(data: data);
+    } on DioException catch (e) {
+      return FailureRepositoryResult(
+        error: e,
+        messages: [networkErrorMsg],
+      );
+    }
+  }
+
+  Future<RepositoryResult<void>> completeTask({required int id}) async {
+    try {
+      await _mainDataSource.completeTask(taskId: id);
+      return SuccessRepositoryResult(
+        data: null,
+      );
+    } on DioException catch (e) {
+      return FailureRepositoryResult(
+        error: e,
+        messages: [networkErrorMsg],
+      );
+    }
   }
 }

--- a/lib/repository/main/model/main_plan_model.dart
+++ b/lib/repository/main/model/main_plan_model.dart
@@ -1,13 +1,61 @@
-import 'package:planit/ui/main/component/task_widget.dart';
+import '../../../data_source/main/reponse_body/today_tasks_response_body.dart';
 
-class MainPlanModel {
-  final String planTitle;
-  final List<TempTaskModel> tasks;
-  final int? dDay;
+class TodayPlanListModel {
+  final List<TodayPlanModel> slowPlans;
+  final List<TodayPlanModel> passionatePlans;
 
-  MainPlanModel({
-    required this.planTitle,
-    required this.tasks,
-    this.dDay,
+  const TodayPlanListModel({
+    required this.slowPlans,
+    required this.passionatePlans,
   });
+
+  TodayPlanListModel.fromResponse(TodayPlanListResponseBody response)
+      : slowPlans = response.slowPlans
+            .map((plan) => TodayPlanModel.fromResponse(plan))
+            .toList(),
+        passionatePlans = response.passionatePlans
+            .map((plan) => TodayPlanModel.fromResponse(plan))
+            .toList();
+}
+
+class TodayPlanModel {
+  final int planId;
+  final String title;
+  final List<TaskStatusModel> tasks;
+  final String dDay;
+
+  const TodayPlanModel({
+    required this.planId,
+    required this.title,
+    required this.tasks,
+    required this.dDay,
+  });
+
+  TodayPlanModel.fromResponse(TodayPlanResponseBody response)
+      : planId = response.planId,
+        title = response.title,
+        tasks = response.tasks
+            .map((task) => TaskStatusModel.fromResponse(task))
+            .toList(),
+        dDay = response.dDay;
+}
+
+class TaskStatusModel {
+  final int taskId;
+  final String title;
+  final String routineTime;
+  final bool isCompleted;
+
+  const TaskStatusModel({
+    required this.taskId,
+    required this.title,
+    required this.routineTime,
+    required this.isCompleted,
+  });
+
+  TaskStatusModel.fromResponse(TaskStatusResponseBody response)
+      : taskId = response.taskId,
+        title = response.title,
+        routineTime = response.routineTime,
+        isCompleted = response.isCompleted;
 }

--- a/lib/repository/main/model/main_plan_model.dart
+++ b/lib/repository/main/model/main_plan_model.dart
@@ -43,19 +43,16 @@ class TodayPlanModel {
 class TaskStatusModel {
   final int taskId;
   final String title;
-  final String routineTime;
   final bool isCompleted;
 
   const TaskStatusModel({
     required this.taskId,
     required this.title,
-    required this.routineTime,
     required this.isCompleted,
   });
 
   TaskStatusModel.fromResponse(TaskStatusResponseBody response)
       : taskId = response.taskId,
         title = response.title,
-        routineTime = response.routineTime,
         isCompleted = response.isCompleted;
 }

--- a/lib/service/storage/storage_key.dart
+++ b/lib/service/storage/storage_key.dart
@@ -12,7 +12,4 @@ class StorageKey {
 
   // GuiltyFreeStatus 저장
   static const guiltyFreeStatus = 'guiltyFreeStatus';
-
-  // 마지막으로 회복루틴을 사용한 날짜
-  static const lastRecoveryRoutineDate = 'lastRecoveryRoutineDate';
 }

--- a/lib/service/storage/storage_key.dart
+++ b/lib/service/storage/storage_key.dart
@@ -12,4 +12,7 @@ class StorageKey {
 
   // GuiltyFreeStatus 저장
   static const guiltyFreeStatus = 'guiltyFreeStatus';
+
+  // 마지막으로 태스크를 달성한 날짜 (첫 달성 확인 용도)
+  static const lastCompleteTaskDate = 'lastCompleteTaskDate';
 }

--- a/lib/ui/common/comopnent/planit_bottom_sheet.dart
+++ b/lib/ui/common/comopnent/planit_bottom_sheet.dart
@@ -46,6 +46,7 @@ class PlanitBottomSheet extends StatelessWidget {
           bottom: 40.0,
         ),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             _PlanitBottomSheetHandle(),
             content,

--- a/lib/ui/main/component/main_top_widget.dart
+++ b/lib/ui/main/component/main_top_widget.dart
@@ -118,13 +118,13 @@ String getAsset({
   required TaskStatus status,
 }) {
   if (type == RouteType.slow) {
-    if (status == TaskStatus.none) {
+    if (status == TaskStatus.nothing) {
       return Assets.mascotSeatingMonochrome;
     } else {
       return Assets.mascotSeatingColor;
     }
   } else {
-    if (status == TaskStatus.none) {
+    if (status == TaskStatus.nothing) {
       return Assets.mascotDancingMonochrome;
     } else {
       return Assets.mascotDancingColor;

--- a/lib/ui/main/component/main_top_widget.dart
+++ b/lib/ui/main/component/main_top_widget.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:numberpicker/numberpicker.dart';
+import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/ui/guilty_free/start/view/guilty_free_blocked_view.dart';
 import 'package:planit/ui/mypage/view/mypage_view.dart';
 
+import '../../../theme/planit_typos.dart';
 import '../../common/assets.dart';
 import '../../guilty_free/start/view/guilty_free_intro_view.dart';
 import '../const/main_enums.dart';
@@ -39,6 +42,31 @@ class MainTopWidget extends StatelessWidget {
         height: 200.0,
         child: Stack(
           children: [
+            // 연속일
+            Positioned(
+              left: 0.0,
+              right: 0.0,
+              bottom: -40,
+              child: NumberPicker(
+                itemHeight: 90,
+                itemWidth: 200,
+                onChanged: (value) {},
+                maxValue: 103,
+                minValue: 1,
+                value: 102,
+                selectedTextStyle: PlanitTypos.pretendardBlack90.copyWith(
+                  color: status == TaskStatus.nothing
+                      ? PlanitColors.white02
+                      : (status == TaskStatus.allPassionate
+                          ? PlanitColors.primary
+                          : PlanitColors.black01),
+                ),
+                textStyle: PlanitTypos.pretendardBlack40.copyWith(
+                  color: PlanitColors.white02,
+                ),
+              ),
+            ),
+            // 마이페이지 버튼
             Positioned(
               left: 0.0,
               child: IconButton(
@@ -51,6 +79,7 @@ class MainTopWidget extends StatelessWidget {
                 padding: EdgeInsets.zero,
               ),
             ),
+            // 길티프리 버튼
             Positioned(
               right: 0.0,
               child: IconButton(
@@ -71,6 +100,7 @@ class MainTopWidget extends StatelessWidget {
                 padding: EdgeInsets.zero,
               ),
             ),
+            // 마스코트 에셋
             Positioned(
               left: 0.0,
               bottom: 0.0,

--- a/lib/ui/main/component/plan_list_view.dart
+++ b/lib/ui/main/component/plan_list_view.dart
@@ -8,7 +8,7 @@ import '../../../theme/planit_typos.dart';
 import '../main_view_model.dart';
 
 class PlanListView extends StatelessWidget {
-  final List<MainPlanModel> plans;
+  final List<TodayPlanModel> plans;
   final bool showRecoveryRoutineBanner;
   final OnCheckboxTap onCheckboxTap;
 
@@ -68,11 +68,11 @@ class PlanListView extends StatelessWidget {
                   if (index == 0) {
                     return RecoveryRoutineBanner();
                   } else {
-                    final MainPlanModel plan = plans[index - 1];
+                    final TodayPlanModel plan = plans[index - 1];
                     return Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8.0),
                       child: TaskWidget(
-                        planTitle: plan.planTitle,
+                        planTitle: plan.title,
                         tasks: plan.tasks,
                         dDay: plan.dDay,
                         planIndex: index - 1,
@@ -83,11 +83,11 @@ class PlanListView extends StatelessWidget {
                 }
                 // 회복 루틴 배너가 노출되지 않을 때
                 else {
-                  final MainPlanModel plan = plans[index];
+                  final TodayPlanModel plan = plans[index];
                   return Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8.0),
                     child: TaskWidget(
-                      planTitle: plan.planTitle,
+                      planTitle: plan.title,
                       tasks: plan.tasks,
                       dDay: plan.dDay,
                       planIndex: index,

--- a/lib/ui/main/component/recovery_routine_banner.dart
+++ b/lib/ui/main/component/recovery_routine_banner.dart
@@ -26,29 +26,15 @@ class RecoveryRoutineBanner extends StatelessWidget {
           borderRadius: BorderRadiusGeometry.circular(12.0),
         ),
         padding: EdgeInsetsGeometry.symmetric(
-          horizontal: 20.0,
           vertical: 16.0,
         ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            PlanitText(
-              '할 일 시작이 어려우신가요?',
-              style: PlanitTypos.body2.copyWith(
-                color: PlanitColors.white01,
-              ),
+        child: Center(
+          child: PlanitText(
+            '할 일 시작이 어려우신가요?',
+            style: PlanitTypos.body2.copyWith(
+              color: PlanitColors.white01,
             ),
-            IconButton(
-              onPressed: () {},
-              icon: SvgPicture.asset(
-                Assets.x,
-                colorFilter: ColorFilter.mode(
-                  PlanitColors.white01,
-                  BlendMode.srcIn,
-                ),
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/ui/main/component/recovery_routine_banner.dart
+++ b/lib/ui/main/component/recovery_routine_banner.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:planit/ui/recovery/recovery_intro_view.dart';
 
 import '../../../theme/planit_colors.dart';
 import '../../../theme/planit_typos.dart';
-import '../../common/assets.dart';
 import '../../common/comopnent/planit_text.dart';
 
 class RecoveryRoutineBanner extends StatelessWidget {

--- a/lib/ui/main/component/task_widget.dart
+++ b/lib/ui/main/component/task_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:planit/repository/main/model/main_plan_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
+import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 
 import '../../common/comopnent/planit_checkbox.dart';
@@ -80,9 +81,53 @@ class _Task extends StatelessWidget {
             onTap: () {
               // 미완료일 때만 체크 허용
               if (!task.isCompleted) {
-                onCheckboxTap(
-                  taskId: task.taskId,
-                  isCurrentCompleted: task.isCompleted,
+                showModalBottomSheet(
+                  context: context,
+                  builder: (context) => PlanitBottomSheet(
+                    content: Column(
+                      children: [
+                        SizedBox(height: 20.0),
+                        PlanitText(
+                          '할 일을 마치셨나요?',
+                          style: PlanitTypos.title3.copyWith(
+                            color: PlanitColors.black01,
+                          ),
+                        ),
+                        SizedBox(height: 16.0),
+                        GestureDetector(
+                          onTap: () => onCheckboxTap(
+                            taskId: task.taskId,
+                            isCurrentCompleted: task.isCompleted,
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 16.0),
+                            child: PlanitText(
+                              '네',
+                              style: PlanitTypos.body2.copyWith(
+                                color: PlanitColors.red,
+                              ),
+                            ),
+                          ),
+                        ),
+                        Divider(
+                          height: 0.5,
+                          color: PlanitColors.white03,
+                        ),
+                        GestureDetector(
+                          onTap: () => Navigator.of(context).pop(),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 16.0),
+                            child: PlanitText(
+                              '아니오',
+                              style: PlanitTypos.body2.copyWith(
+                                color: PlanitColors.black01,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 );
               }
             },

--- a/lib/ui/main/component/task_widget.dart
+++ b/lib/ui/main/component/task_widget.dart
@@ -43,8 +43,6 @@ class TaskWidget extends StatelessWidget {
             ...tasks.asMap().entries.map(
                   (MapEntry<int, TaskStatusModel> e) => _Task(
                     task: e.value,
-                    planIndex: planIndex,
-                    taskIndex: e.key,
                     onCheckboxTap: onCheckboxTap,
                   ),
                 ),
@@ -63,14 +61,10 @@ class TaskWidget extends StatelessWidget {
 class _Task extends StatelessWidget {
   final TaskStatusModel task;
   final OnCheckboxTap onCheckboxTap;
-  final int planIndex;
-  final int taskIndex;
 
   const _Task({
     required this.task,
     required this.onCheckboxTap,
-    required this.planIndex,
-    required this.taskIndex,
   });
 
   @override
@@ -83,11 +77,15 @@ class _Task extends StatelessWidget {
         spacing: 10.0,
         children: [
           GestureDetector(
-            onTap: () => onCheckboxTap(
-              planIndex: planIndex,
-              taskIndex: taskIndex,
-              isCurrentCompleted: task.isCompleted,
-            ),
+            onTap: () {
+              // 미완료일 때만 체크 허용
+              if (!task.isCompleted) {
+                onCheckboxTap(
+                  taskId: task.taskId,
+                  isCurrentCompleted: task.isCompleted,
+                );
+              }
+            },
             child: PlanitCheckbox(
               isChecked: task.isCompleted,
             ),

--- a/lib/ui/main/component/task_widget.dart
+++ b/lib/ui/main/component/task_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:planit/repository/main/model/main_plan_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
@@ -8,8 +9,8 @@ import '../main_view_model.dart';
 
 class TaskWidget extends StatelessWidget {
   final String planTitle;
-  final List<TempTaskModel> tasks;
-  final int? dDay;
+  final List<TaskStatusModel> tasks;
+  final String dDay;
   final int planIndex;
   final OnCheckboxTap onCheckboxTap;
 
@@ -40,7 +41,7 @@ class TaskWidget extends StatelessWidget {
             _PlanTitle(planTitle: planTitle),
             SizedBox(height: 8.0),
             ...tasks.asMap().entries.map(
-                  (MapEntry<int, TempTaskModel> e) => _Task(
+                  (MapEntry<int, TaskStatusModel> e) => _Task(
                     task: e.value,
                     planIndex: planIndex,
                     taskIndex: e.key,
@@ -60,7 +61,7 @@ class TaskWidget extends StatelessWidget {
 }
 
 class _Task extends StatelessWidget {
-  final TempTaskModel task;
+  final TaskStatusModel task;
   final OnCheckboxTap onCheckboxTap;
   final int planIndex;
   final int taskIndex;
@@ -93,7 +94,7 @@ class _Task extends StatelessWidget {
           ),
           Expanded(
             child: PlanitText(
-              task.task,
+              task.title,
               style: task.isCompleted
                   ? PlanitTypos.body2.copyWith(
                       color: PlanitColors.black03,
@@ -110,7 +111,7 @@ class _Task extends StatelessWidget {
 }
 
 class _DDay extends StatelessWidget {
-  final int? dDay;
+  final String dDay;
 
   const _DDay({
     required this.dDay,
@@ -118,7 +119,7 @@ class _DDay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return (dDay == null)
+    return (dDay.isEmpty)
         ? SizedBox.shrink()
         : Container(
             decoration: BoxDecoration(
@@ -133,7 +134,7 @@ class _DDay extends StatelessWidget {
               vertical: 4.0,
             ),
             child: PlanitText(
-              'D-$dDay',
+              dDay,
               style: TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w400,

--- a/lib/ui/main/const/main_enums.dart
+++ b/lib/ui/main/const/main_enums.dart
@@ -5,7 +5,8 @@ enum RouteType {
 }
 
 enum TaskStatus {
-  none, // 아무것도 안한 상태
+  none, // 초기 상태
+  nothing, // 아무것도 안 한 상태
   partial, // 하나 이상 태스트 달성
   allPassionate; // 열정 태스크 모두 달성
 }

--- a/lib/ui/main/main_state.dart
+++ b/lib/ui/main/main_state.dart
@@ -5,11 +5,17 @@ import 'package:planit/ui/main/const/main_enums.dart';
 
 part 'main_state.freezed.dart';
 
+// emptyPlans = TodayPlanListModel(slowPlans: [], passionatePlans: []);
+
 @freezed
 abstract class MainState with _$MainState {
-  const factory MainState({
+  factory MainState({
     @Default(RouteType.slow) RouteType routeType,
-    @Default([]) List<MainPlanModel> plans,
+    @Default(TodayPlanListModel(
+      slowPlans: [],
+      passionatePlans: [],
+    ))
+    TodayPlanListModel plans,
     @Default(TaskStatus.none) TaskStatus taskStatus,
     @Default(LoadingStatus.none) LoadingStatus loadingStatus,
     @Default(true) bool showRecoveryRoutineBanner,

--- a/lib/ui/main/main_state.dart
+++ b/lib/ui/main/main_state.dart
@@ -22,6 +22,5 @@ abstract class MainState with _$MainState {
     @Default('') String errorMessage,
     @Default('') String completeMessage,
     @Default(null) bool? canUseGuiltyFree,
-    @Default(false) bool didFirstComplete,
   }) = _MainState;
 }

--- a/lib/ui/main/main_state.dart
+++ b/lib/ui/main/main_state.dart
@@ -22,5 +22,6 @@ abstract class MainState with _$MainState {
     @Default('') String errorMessage,
     @Default('') String completeMessage,
     @Default(null) bool? canUseGuiltyFree,
+    @Default(false) bool didFirstComplete,
   }) = _MainState;
 }

--- a/lib/ui/main/main_state.freezed.dart
+++ b/lib/ui/main/main_state.freezed.dart
@@ -23,6 +23,7 @@ mixin _$MainState {
   String get errorMessage;
   String get completeMessage;
   bool? get canUseGuiltyFree;
+  bool get didFirstComplete;
 
   /// Create a copy of MainState
   /// with the given fields replaced by the non-null parameter values.
@@ -51,7 +52,9 @@ mixin _$MainState {
             (identical(other.completeMessage, completeMessage) ||
                 other.completeMessage == completeMessage) &&
             (identical(other.canUseGuiltyFree, canUseGuiltyFree) ||
-                other.canUseGuiltyFree == canUseGuiltyFree));
+                other.canUseGuiltyFree == canUseGuiltyFree) &&
+            (identical(other.didFirstComplete, didFirstComplete) ||
+                other.didFirstComplete == didFirstComplete));
   }
 
   @override
@@ -64,11 +67,12 @@ mixin _$MainState {
       showRecoveryRoutineBanner,
       errorMessage,
       completeMessage,
-      canUseGuiltyFree);
+      canUseGuiltyFree,
+      didFirstComplete);
 
   @override
   String toString() {
-    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree)';
+    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree, didFirstComplete: $didFirstComplete)';
   }
 }
 
@@ -85,7 +89,8 @@ abstract mixin class $MainStateCopyWith<$Res> {
       bool showRecoveryRoutineBanner,
       String errorMessage,
       String completeMessage,
-      bool? canUseGuiltyFree});
+      bool? canUseGuiltyFree,
+      bool didFirstComplete});
 }
 
 /// @nodoc
@@ -108,6 +113,7 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
     Object? errorMessage = null,
     Object? completeMessage = null,
     Object? canUseGuiltyFree = freezed,
+    Object? didFirstComplete = null,
   }) {
     return _then(_self.copyWith(
       routeType: null == routeType
@@ -142,6 +148,10 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
           ? _self.canUseGuiltyFree
           : canUseGuiltyFree // ignore: cast_nullable_to_non_nullable
               as bool?,
+      didFirstComplete: null == didFirstComplete
+          ? _self.didFirstComplete
+          : didFirstComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -157,7 +167,8 @@ class _MainState implements MainState {
       this.showRecoveryRoutineBanner = true,
       this.errorMessage = '',
       this.completeMessage = '',
-      this.canUseGuiltyFree = null});
+      this.canUseGuiltyFree = null,
+      this.didFirstComplete = false});
 
   @override
   @JsonKey()
@@ -183,6 +194,9 @@ class _MainState implements MainState {
   @override
   @JsonKey()
   final bool? canUseGuiltyFree;
+  @override
+  @JsonKey()
+  final bool didFirstComplete;
 
   /// Create a copy of MainState
   /// with the given fields replaced by the non-null parameter values.
@@ -212,7 +226,9 @@ class _MainState implements MainState {
             (identical(other.completeMessage, completeMessage) ||
                 other.completeMessage == completeMessage) &&
             (identical(other.canUseGuiltyFree, canUseGuiltyFree) ||
-                other.canUseGuiltyFree == canUseGuiltyFree));
+                other.canUseGuiltyFree == canUseGuiltyFree) &&
+            (identical(other.didFirstComplete, didFirstComplete) ||
+                other.didFirstComplete == didFirstComplete));
   }
 
   @override
@@ -225,11 +241,12 @@ class _MainState implements MainState {
       showRecoveryRoutineBanner,
       errorMessage,
       completeMessage,
-      canUseGuiltyFree);
+      canUseGuiltyFree,
+      didFirstComplete);
 
   @override
   String toString() {
-    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree)';
+    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree, didFirstComplete: $didFirstComplete)';
   }
 }
 
@@ -249,7 +266,8 @@ abstract mixin class _$MainStateCopyWith<$Res>
       bool showRecoveryRoutineBanner,
       String errorMessage,
       String completeMessage,
-      bool? canUseGuiltyFree});
+      bool? canUseGuiltyFree,
+      bool didFirstComplete});
 }
 
 /// @nodoc
@@ -272,6 +290,7 @@ class __$MainStateCopyWithImpl<$Res> implements _$MainStateCopyWith<$Res> {
     Object? errorMessage = null,
     Object? completeMessage = null,
     Object? canUseGuiltyFree = freezed,
+    Object? didFirstComplete = null,
   }) {
     return _then(_MainState(
       routeType: null == routeType
@@ -306,6 +325,10 @@ class __$MainStateCopyWithImpl<$Res> implements _$MainStateCopyWith<$Res> {
           ? _self.canUseGuiltyFree
           : canUseGuiltyFree // ignore: cast_nullable_to_non_nullable
               as bool?,
+      didFirstComplete: null == didFirstComplete
+          ? _self.didFirstComplete
+          : didFirstComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }

--- a/lib/ui/main/main_state.freezed.dart
+++ b/lib/ui/main/main_state.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MainState {
   RouteType get routeType;
-  List<MainPlanModel> get plans;
+  TodayPlanListModel get plans;
   TaskStatus get taskStatus;
   LoadingStatus get loadingStatus;
   bool get showRecoveryRoutineBanner;
@@ -38,7 +38,7 @@ mixin _$MainState {
             other is MainState &&
             (identical(other.routeType, routeType) ||
                 other.routeType == routeType) &&
-            const DeepCollectionEquality().equals(other.plans, plans) &&
+            (identical(other.plans, plans) || other.plans == plans) &&
             (identical(other.taskStatus, taskStatus) ||
                 other.taskStatus == taskStatus) &&
             (identical(other.loadingStatus, loadingStatus) ||
@@ -58,7 +58,7 @@ mixin _$MainState {
   int get hashCode => Object.hash(
       runtimeType,
       routeType,
-      const DeepCollectionEquality().hash(plans),
+      plans,
       taskStatus,
       loadingStatus,
       showRecoveryRoutineBanner,
@@ -79,7 +79,7 @@ abstract mixin class $MainStateCopyWith<$Res> {
   @useResult
   $Res call(
       {RouteType routeType,
-      List<MainPlanModel> plans,
+      TodayPlanListModel plans,
       TaskStatus taskStatus,
       LoadingStatus loadingStatus,
       bool showRecoveryRoutineBanner,
@@ -117,7 +117,7 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
       plans: null == plans
           ? _self.plans
           : plans // ignore: cast_nullable_to_non_nullable
-              as List<MainPlanModel>,
+              as TodayPlanListModel,
       taskStatus: null == taskStatus
           ? _self.taskStatus
           : taskStatus // ignore: cast_nullable_to_non_nullable
@@ -149,29 +149,22 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
 /// @nodoc
 
 class _MainState implements MainState {
-  const _MainState(
+  _MainState(
       {this.routeType = RouteType.slow,
-      final List<MainPlanModel> plans = const [],
+      this.plans = const TodayPlanListModel(slowPlans: [], passionatePlans: []),
       this.taskStatus = TaskStatus.none,
       this.loadingStatus = LoadingStatus.none,
       this.showRecoveryRoutineBanner = true,
       this.errorMessage = '',
       this.completeMessage = '',
-      this.canUseGuiltyFree = null})
-      : _plans = plans;
+      this.canUseGuiltyFree = null});
 
   @override
   @JsonKey()
   final RouteType routeType;
-  final List<MainPlanModel> _plans;
   @override
   @JsonKey()
-  List<MainPlanModel> get plans {
-    if (_plans is EqualUnmodifiableListView) return _plans;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_plans);
-  }
-
+  final TodayPlanListModel plans;
   @override
   @JsonKey()
   final TaskStatus taskStatus;
@@ -206,7 +199,7 @@ class _MainState implements MainState {
             other is _MainState &&
             (identical(other.routeType, routeType) ||
                 other.routeType == routeType) &&
-            const DeepCollectionEquality().equals(other._plans, _plans) &&
+            (identical(other.plans, plans) || other.plans == plans) &&
             (identical(other.taskStatus, taskStatus) ||
                 other.taskStatus == taskStatus) &&
             (identical(other.loadingStatus, loadingStatus) ||
@@ -226,7 +219,7 @@ class _MainState implements MainState {
   int get hashCode => Object.hash(
       runtimeType,
       routeType,
-      const DeepCollectionEquality().hash(_plans),
+      plans,
       taskStatus,
       loadingStatus,
       showRecoveryRoutineBanner,
@@ -250,7 +243,7 @@ abstract mixin class _$MainStateCopyWith<$Res>
   @useResult
   $Res call(
       {RouteType routeType,
-      List<MainPlanModel> plans,
+      TodayPlanListModel plans,
       TaskStatus taskStatus,
       LoadingStatus loadingStatus,
       bool showRecoveryRoutineBanner,
@@ -286,9 +279,9 @@ class __$MainStateCopyWithImpl<$Res> implements _$MainStateCopyWith<$Res> {
           : routeType // ignore: cast_nullable_to_non_nullable
               as RouteType,
       plans: null == plans
-          ? _self._plans
+          ? _self.plans
           : plans // ignore: cast_nullable_to_non_nullable
-              as List<MainPlanModel>,
+              as TodayPlanListModel,
       taskStatus: null == taskStatus
           ? _self.taskStatus
           : taskStatus // ignore: cast_nullable_to_non_nullable

--- a/lib/ui/main/main_state.freezed.dart
+++ b/lib/ui/main/main_state.freezed.dart
@@ -23,7 +23,6 @@ mixin _$MainState {
   String get errorMessage;
   String get completeMessage;
   bool? get canUseGuiltyFree;
-  bool get didFirstComplete;
 
   /// Create a copy of MainState
   /// with the given fields replaced by the non-null parameter values.
@@ -52,9 +51,7 @@ mixin _$MainState {
             (identical(other.completeMessage, completeMessage) ||
                 other.completeMessage == completeMessage) &&
             (identical(other.canUseGuiltyFree, canUseGuiltyFree) ||
-                other.canUseGuiltyFree == canUseGuiltyFree) &&
-            (identical(other.didFirstComplete, didFirstComplete) ||
-                other.didFirstComplete == didFirstComplete));
+                other.canUseGuiltyFree == canUseGuiltyFree));
   }
 
   @override
@@ -67,12 +64,11 @@ mixin _$MainState {
       showRecoveryRoutineBanner,
       errorMessage,
       completeMessage,
-      canUseGuiltyFree,
-      didFirstComplete);
+      canUseGuiltyFree);
 
   @override
   String toString() {
-    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree, didFirstComplete: $didFirstComplete)';
+    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree)';
   }
 }
 
@@ -89,8 +85,7 @@ abstract mixin class $MainStateCopyWith<$Res> {
       bool showRecoveryRoutineBanner,
       String errorMessage,
       String completeMessage,
-      bool? canUseGuiltyFree,
-      bool didFirstComplete});
+      bool? canUseGuiltyFree});
 }
 
 /// @nodoc
@@ -113,7 +108,6 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
     Object? errorMessage = null,
     Object? completeMessage = null,
     Object? canUseGuiltyFree = freezed,
-    Object? didFirstComplete = null,
   }) {
     return _then(_self.copyWith(
       routeType: null == routeType
@@ -148,10 +142,6 @@ class _$MainStateCopyWithImpl<$Res> implements $MainStateCopyWith<$Res> {
           ? _self.canUseGuiltyFree
           : canUseGuiltyFree // ignore: cast_nullable_to_non_nullable
               as bool?,
-      didFirstComplete: null == didFirstComplete
-          ? _self.didFirstComplete
-          : didFirstComplete // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }
@@ -167,8 +157,7 @@ class _MainState implements MainState {
       this.showRecoveryRoutineBanner = true,
       this.errorMessage = '',
       this.completeMessage = '',
-      this.canUseGuiltyFree = null,
-      this.didFirstComplete = false});
+      this.canUseGuiltyFree = null});
 
   @override
   @JsonKey()
@@ -194,9 +183,6 @@ class _MainState implements MainState {
   @override
   @JsonKey()
   final bool? canUseGuiltyFree;
-  @override
-  @JsonKey()
-  final bool didFirstComplete;
 
   /// Create a copy of MainState
   /// with the given fields replaced by the non-null parameter values.
@@ -226,9 +212,7 @@ class _MainState implements MainState {
             (identical(other.completeMessage, completeMessage) ||
                 other.completeMessage == completeMessage) &&
             (identical(other.canUseGuiltyFree, canUseGuiltyFree) ||
-                other.canUseGuiltyFree == canUseGuiltyFree) &&
-            (identical(other.didFirstComplete, didFirstComplete) ||
-                other.didFirstComplete == didFirstComplete));
+                other.canUseGuiltyFree == canUseGuiltyFree));
   }
 
   @override
@@ -241,12 +225,11 @@ class _MainState implements MainState {
       showRecoveryRoutineBanner,
       errorMessage,
       completeMessage,
-      canUseGuiltyFree,
-      didFirstComplete);
+      canUseGuiltyFree);
 
   @override
   String toString() {
-    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree, didFirstComplete: $didFirstComplete)';
+    return 'MainState(routeType: $routeType, plans: $plans, taskStatus: $taskStatus, loadingStatus: $loadingStatus, showRecoveryRoutineBanner: $showRecoveryRoutineBanner, errorMessage: $errorMessage, completeMessage: $completeMessage, canUseGuiltyFree: $canUseGuiltyFree)';
   }
 }
 
@@ -266,8 +249,7 @@ abstract mixin class _$MainStateCopyWith<$Res>
       bool showRecoveryRoutineBanner,
       String errorMessage,
       String completeMessage,
-      bool? canUseGuiltyFree,
-      bool didFirstComplete});
+      bool? canUseGuiltyFree});
 }
 
 /// @nodoc
@@ -290,7 +272,6 @@ class __$MainStateCopyWithImpl<$Res> implements _$MainStateCopyWith<$Res> {
     Object? errorMessage = null,
     Object? completeMessage = null,
     Object? canUseGuiltyFree = freezed,
-    Object? didFirstComplete = null,
   }) {
     return _then(_MainState(
       routeType: null == routeType
@@ -325,10 +306,6 @@ class __$MainStateCopyWithImpl<$Res> implements _$MainStateCopyWith<$Res> {
           ? _self.canUseGuiltyFree
           : canUseGuiltyFree // ignore: cast_nullable_to_non_nullable
               as bool?,
-      didFirstComplete: null == didFirstComplete
-          ? _self.didFirstComplete
-          : didFirstComplete // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -47,6 +47,21 @@ class MainView extends HookConsumerWidget {
       return null;
     }, [state.completeMessage]);
 
+    // taskStatus를 감지하여, nothing에서 partial로 변경될 때에만 첫달성 화면 노출
+    useValueChanged<TaskStatus, void>(state.taskStatus, (oldValue, _) {
+      if (oldValue == TaskStatus.nothing && state.taskStatus == TaskStatus.partial) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => FirstCompleteView(
+                consecutiveDays: 102,
+              ),
+            ),
+          );
+        });
+      }
+    });
+
     return DefaultLayout(
       child: Stack(
         children: [
@@ -57,17 +72,6 @@ class MainView extends HookConsumerWidget {
                 type: state.routeType,
                 onGuiltyFreePressed: viewModel.checkCanUseGuiltyFree(),
                 canUseGuiltyFree: state.canUseGuiltyFree,
-              ),
-              // 첫 달성 화면 확인용 임시 버튼
-              TextButton(
-                onPressed: () => Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => FirstCompleteView(
-                      consecutiveDays: 102,
-                    ),
-                  ),
-                ),
-                child: Text('첫 달성'),
               ),
               RouteSwitchBanner(
                 type: state.routeType,

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -78,9 +78,7 @@ class MainView extends HookConsumerWidget {
                   currentType: state.routeType,
                 ),
               ),
-              (state.loadingStatus == LoadingStatus.loading)
-                  ? SizedBox.shrink()
-                  : PlanListView(
+              PlanListView(
                       plans: state.routeType == RouteType.slow
                           ? state.plans.slowPlans
                           : state.plans.passionatePlans,

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -79,13 +79,12 @@ class MainView extends HookConsumerWidget {
                 ),
               ),
               PlanListView(
-                      plans: state.routeType == RouteType.slow
-                          ? state.plans.slowPlans
-                          : state.plans.passionatePlans,
-                      showRecoveryRoutineBanner:
-                          state.showRecoveryRoutineBanner,
-                      onCheckboxTap: viewModel.onCheckboxTap,
-                    ),
+                plans: state.routeType == RouteType.slow
+                    ? state.plans.slowPlans
+                    : state.plans.passionatePlans,
+                showRecoveryRoutineBanner: state.showRecoveryRoutineBanner,
+                onCheckboxTap: viewModel.onCheckboxTap,
+              ),
             ],
           ),
           if (state.loadingStatus == LoadingStatus.loading)

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -6,6 +6,7 @@ import 'package:planit/ui/common/comopnent/planit_loading.dart';
 import 'package:planit/ui/common/comopnent/planit_toast.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:planit/ui/main/const/main_enums.dart';
 import 'package:planit/ui/main/main_state.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:planit/ui/main/main_view_model.dart';
@@ -80,7 +81,9 @@ class MainView extends HookConsumerWidget {
               (state.loadingStatus == LoadingStatus.loading)
                   ? SizedBox.shrink()
                   : PlanListView(
-                      plans: state.plans,
+                      plans: state.routeType == RouteType.slow
+                          ? state.plans.slowPlans
+                          : state.plans.passionatePlans,
                       showRecoveryRoutineBanner:
                           state.showRecoveryRoutineBanner,
                       onCheckboxTap: viewModel.onCheckboxTap,

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -54,7 +54,7 @@ class MainViewModel extends StateNotifier<MainState> {
     final DateTime today = DateTime.now();
     // 오늘 이전이 아니라면 == 오늘이거나, 오늘 이후라면>첫 달성을 한 것
     if (!lastCompleteTaskDate!.isBefore(today)) {
-      state = state.copyWith(didFirstComplete: true);
+      state = state.copyWith(taskStatus: TaskStatus.partial);
     }
   }
 
@@ -103,9 +103,9 @@ class MainViewModel extends StateNotifier<MainState> {
       case SuccessRepositoryResult():
         // 리스트 갱신
         await getTodayPlans();
-        // 첫달성이라면 상태 변경
-        if (!state.didFirstComplete) {
-          state = state.copyWith(didFirstComplete: true);
+        // 첫달성이라면==아무것도 안 했다면 상태 변경
+        if (state.taskStatus==TaskStatus.none) {
+          state = state.copyWith(taskStatus: TaskStatus.partial);
           _storageService.setString(
             key: StorageKey.lastCompleteTaskDate,
             value: DateTime.now().toString(),

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -35,17 +35,9 @@ class MainViewModel extends StateNotifier<MainState> {
         _storageService = storageService,
         super(MainState());
 
-  void d() {
-    state = state.copyWith(taskStatus: TaskStatus.partial);
-    _storageService.setString(
-      key: StorageKey.lastCompleteTaskDate,
-      value: DateTime.now().toString(),
-    );
-  }
-
   // 화면 진입 시 필요한 작업
   Future<void> init() async {
-    getTodayPlans();
+    await getTodayPlans();
     await checkDidFirstComplete();
     checkDidAllPassinatePlans();
     debugPrint('taskStatus 판단 완료: ${state.taskStatus}');
@@ -120,7 +112,7 @@ class MainViewModel extends StateNotifier<MainState> {
         // 리스트 갱신
         await getTodayPlans();
         // 첫달성이라면==아무것도 안 했다면 상태 변경
-        if (state.taskStatus == TaskStatus.none) {
+        if (state.taskStatus == TaskStatus.nothing) {
           state = state.copyWith(taskStatus: TaskStatus.partial);
           _storageService.setString(
             key: StorageKey.lastCompleteTaskDate,
@@ -145,16 +137,8 @@ class MainViewModel extends StateNotifier<MainState> {
   }
 
   void checkDidAllPassinatePlans() {
-    bool didAll = true;
-    state.plans.passionatePlans.map(
-      (plan) => plan.tasks.map(
-        (task) {
-          // 하나라도 완료되지 않은 태스크 존재>false
-          if (!task.isCompleted) {
-            didAll = false;
-          }
-        },
-      ),
+    final bool didAll = state.plans.passionatePlans.every(
+      (plan) => plan.tasks.every((task) => task.isCompleted),
     );
     if (didAll) {
       state = state.copyWith(taskStatus: TaskStatus.allPassionate);

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -34,6 +34,15 @@ class MainViewModel extends StateNotifier<MainState> {
         _storageService = storageService,
         super(MainState());
 
+  void d(){
+    state = state.copyWith(taskStatus: TaskStatus.partial);
+    _storageService.setString(
+      key: StorageKey.lastCompleteTaskDate,
+      value: DateTime.now().toString(),
+    );
+
+  }
+
   // 화면 진입 시 필요한 작업
   Future<void> init() async {
     getTodayPlans();
@@ -46,7 +55,10 @@ class MainViewModel extends StateNotifier<MainState> {
       defaultValue: '',
     );
     // 저장된 날짜가 없다면 오늘 첫달성 하지 못한 것
-    if (lastCompleteTaskDateString.isEmpty) return;
+    if (lastCompleteTaskDateString.isEmpty) {
+      state=state.copyWith(taskStatus: TaskStatus.nothing);
+      return;
+    }
 
     final DateTime? lastCompleteTaskDate = stringToDateTime(
       lastCompleteTaskDateString,
@@ -55,6 +67,8 @@ class MainViewModel extends StateNotifier<MainState> {
     // 오늘 이전이 아니라면 == 오늘이거나, 오늘 이후라면>첫 달성을 한 것
     if (!lastCompleteTaskDate!.isBefore(today)) {
       state = state.copyWith(taskStatus: TaskStatus.partial);
+    } else {
+      state=state.copyWith(taskStatus: TaskStatus.nothing);
     }
   }
 

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/core/repository_result.dart';
 import 'package:planit/repository/guilty_free/guilty_free_repository.dart';
@@ -7,7 +6,6 @@ import 'package:planit/repository/main/main_repository.dart';
 import 'package:planit/repository/main/model/main_plan_model.dart';
 import 'package:planit/service/storage/planit_storage_service.dart';
 import 'package:planit/service/storage/storage_key.dart';
-import 'package:planit/ui/main/component/task_widget.dart';
 import 'package:planit/ui/main/const/main_enums.dart';
 import 'package:planit/utils/date_time.dart';
 
@@ -38,28 +36,28 @@ class MainViewModel extends StateNotifier<MainState> {
 
   // 화면 진입 시 필요한 작업
   Future<void> init() async {
-    getMainPlanList();
+    getTodayPlans();
     // 배너 보여줄지 확인해 상태 업데이트
     final bool showBanner = await checkShowRecoveryRoutineBanner();
     state = state.copyWith(showRecoveryRoutineBanner: showBanner);
   }
 
   // 플랜 리스트 불러오기
-  Future<void> getMainPlanList() async {
+  Future<void> getTodayPlans() async {
     // API 호출 전 loadingStatus 변경하여 UI에 로딩바 처리
     state = state.copyWith(loadingStatus: LoadingStatus.loading);
 
-    final RepositoryResult<List<MainPlanModel>> result =
+    final RepositoryResult<TodayPlanListModel> result =
         await _mainRepository.getMainPlanList();
 
     switch (result) {
-      case SuccessRepositoryResult<List<MainPlanModel>>():
+      case SuccessRepositoryResult<TodayPlanListModel>():
         state = state.copyWith(
           loadingStatus: LoadingStatus.success,
           plans: result.data,
         );
 
-      case FailureRepositoryResult<List<MainPlanModel>>():
+      case FailureRepositoryResult():
         state = state.copyWith(
           loadingStatus: LoadingStatus.error,
           errorMessage: '플랜 목록 불러오기에 실패했어요.',
@@ -114,52 +112,52 @@ class MainViewModel extends StateNotifier<MainState> {
     required int taskIndex,
     required bool isCurrentCompleted,
   }) {
-    // isCompleted 값이 업데이트 된 새로운 plan 리스트 구성
-    final updatedPlans = state.plans
-        .asMap()
-        .entries
-        .map((MapEntry<int, MainPlanModel> planEtries) {
-      // planIndex로 플랜 우선 식별하여 변경
-      if (planEtries.key == planIndex) {
-        // 해당 플랜의 tasks 수정
-        final List<TempTaskModel> updatedTasks = planEtries.value.tasks
-            .asMap()
-            .entries
-            .map((MapEntry<int, TempTaskModel> taskEntries) {
-          // 식별된 플랜 내에서 taskIndex로 태스크 식별
-          if (taskEntries.key == taskIndex) {
-            // isCompleted 변경된 태스크 반환
-            return TempTaskModel(
-              isCompleted: !isCurrentCompleted,
-              task: taskEntries.value.task,
-            );
-          } else {
-            // 그 외 태스크 유지
-            return taskEntries.value;
-          }
-        }).toList();
-        // 변경된 플랜 반환
-        return MainPlanModel(
-          planTitle: planEtries.value.planTitle,
-          tasks: updatedTasks,
-          dDay: planEtries.value.dDay,
-        );
-      } else {
-        // 그 외 플랜 유지
-        return planEtries.value;
-      }
-    }).toList();
-    // 변경된 플랜 리스트로 state 업데이트
-    state = state.copyWith(plans: updatedPlans);
-
-    // 체크 안 함>체크 완료로 상태 변경 시 태스크 완료 토스트 노출되도록 message 변경
-    if (!isCurrentCompleted) {
-      state = state.copyWith(completeMessage: '짱이야, 해내버렸어요! 😍');
-      // 다른 태스크 완료 시에도 동작할 수 있도록 잠시 유지 후 초기화
-      Future.delayed(Duration(milliseconds: 2500), () {
-        state = state.copyWith(completeMessage: '');
-      });
-    }
+    // // isCompleted 값이 업데이트 된 새로운 plan 리스트 구성
+    // final updatedPlans = state.plans
+    //     .asMap()
+    //     .entries
+    //     .map((MapEntry<int, MainPlanModel> planEtries) {
+    //   // planIndex로 플랜 우선 식별하여 변경
+    //   if (planEtries.key == planIndex) {
+    //     // 해당 플랜의 tasks 수정
+    //     final List<TempTaskModel> updatedTasks = planEtries.value.tasks
+    //         .asMap()
+    //         .entries
+    //         .map((MapEntry<int, TempTaskModel> taskEntries) {
+    //       // 식별된 플랜 내에서 taskIndex로 태스크 식별
+    //       if (taskEntries.key == taskIndex) {
+    //         // isCompleted 변경된 태스크 반환
+    //         return TempTaskModel(
+    //           isCompleted: !isCurrentCompleted,
+    //           task: taskEntries.value.task,
+    //         );
+    //       } else {
+    //         // 그 외 태스크 유지
+    //         return taskEntries.value;
+    //       }
+    //     }).toList();
+    //     // 변경된 플랜 반환
+    //     return MainPlanModel(
+    //       planTitle: planEtries.value.planTitle,
+    //       tasks: updatedTasks,
+    //       dDay: planEtries.value.dDay,
+    //     );
+    //   } else {
+    //     // 그 외 플랜 유지
+    //     return planEtries.value;
+    //   }
+    // }).toList();
+    // // 변경된 플랜 리스트로 state 업데이트
+    // state = state.copyWith(plans: updatedPlans);
+    //
+    // // 체크 안 함>체크 완료로 상태 변경 시 태스크 완료 토스트 노출되도록 message 변경
+    // if (!isCurrentCompleted) {
+    //   state = state.copyWith(completeMessage: '짱이야, 해내버렸어요! 😍');
+    //   // 다른 태스크 완료 시에도 동작할 수 있도록 잠시 유지 후 초기화
+    //   Future.delayed(Duration(milliseconds: 2500), () {
+    //     state = state.copyWith(completeMessage: '');
+    //   });
+    // }
   }
 
   // 길티프리 모드 사용 가능한지 판단

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -37,9 +37,6 @@ class MainViewModel extends StateNotifier<MainState> {
   // 화면 진입 시 필요한 작업
   Future<void> init() async {
     getTodayPlans();
-    // 배너 보여줄지 확인해 상태 업데이트
-    final bool showBanner = await checkShowRecoveryRoutineBanner();
-    state = state.copyWith(showRecoveryRoutineBanner: showBanner);
   }
 
   // 플랜 리스트 불러오기
@@ -69,41 +66,10 @@ class MainViewModel extends StateNotifier<MainState> {
     required RouteType currentType,
   }) async {
     final bool isSlow = currentType == RouteType.slow;
-    bool showBanner = state.showRecoveryRoutineBanner;
-    // 열정>천천히 전환 시, 회복루틴 배너 노출할지 확인
-    if (!isSlow) {
-      showBanner = await checkShowRecoveryRoutineBanner();
-    }
-    // 천천히>열정 전환 시, 무조건 노출 안 함
-    else {
-      showBanner = false;
-    }
     state = state.copyWith(
       routeType: isSlow ? RouteType.passionate : RouteType.slow,
-      showRecoveryRoutineBanner: showBanner,
+      showRecoveryRoutineBanner: isSlow ? false : true,
     );
-  }
-
-  // 오늘 회복루틴을 한 번도 사용하지 않았을 때에만 배너 노출
-  // TODO: 매번 lastDate 로드, today와 비교해 계산 > 비효율적인 것 같아 개선 필요
-  Future<bool> checkShowRecoveryRoutineBanner() async {
-    final String lastDateString = await _storageService.getString(
-      key: StorageKey.lastRecoveryRoutineDate,
-      defaultValue: '',
-    );
-
-    // 저장된 날짜가 없다면, 사용하지 않은 것이므로 계산없이 true 반환
-    if (lastDateString.isEmpty) {
-      return true;
-    }
-
-    final DateTime? lastDate = stringToDateTime(lastDateString);
-    final DateTime today = DateTime.now();
-
-    if (lastDate!.isBefore(today)) {
-      return true;
-    }
-    return false;
   }
 
   // Checkbox 클릭 시, id 식별하여 plans 변경

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -106,58 +106,31 @@ class MainViewModel extends StateNotifier<MainState> {
     return false;
   }
 
-  // Checkbox 클릭 시, planIndex & taskIndex 함께 사용해 할 일 식별하여 plans 변경
-  void onCheckboxTap({
-    required int planIndex,
-    required int taskIndex,
+  // Checkbox 클릭 시, id 식별하여 plans 변경
+  Future<void> onCheckboxTap({
+    required int taskId,
     required bool isCurrentCompleted,
-  }) {
-    // // isCompleted 값이 업데이트 된 새로운 plan 리스트 구성
-    // final updatedPlans = state.plans
-    //     .asMap()
-    //     .entries
-    //     .map((MapEntry<int, MainPlanModel> planEtries) {
-    //   // planIndex로 플랜 우선 식별하여 변경
-    //   if (planEtries.key == planIndex) {
-    //     // 해당 플랜의 tasks 수정
-    //     final List<TempTaskModel> updatedTasks = planEtries.value.tasks
-    //         .asMap()
-    //         .entries
-    //         .map((MapEntry<int, TempTaskModel> taskEntries) {
-    //       // 식별된 플랜 내에서 taskIndex로 태스크 식별
-    //       if (taskEntries.key == taskIndex) {
-    //         // isCompleted 변경된 태스크 반환
-    //         return TempTaskModel(
-    //           isCompleted: !isCurrentCompleted,
-    //           task: taskEntries.value.task,
-    //         );
-    //       } else {
-    //         // 그 외 태스크 유지
-    //         return taskEntries.value;
-    //       }
-    //     }).toList();
-    //     // 변경된 플랜 반환
-    //     return MainPlanModel(
-    //       planTitle: planEtries.value.planTitle,
-    //       tasks: updatedTasks,
-    //       dDay: planEtries.value.dDay,
-    //     );
-    //   } else {
-    //     // 그 외 플랜 유지
-    //     return planEtries.value;
-    //   }
-    // }).toList();
-    // // 변경된 플랜 리스트로 state 업데이트
-    // state = state.copyWith(plans: updatedPlans);
-    //
-    // // 체크 안 함>체크 완료로 상태 변경 시 태스크 완료 토스트 노출되도록 message 변경
-    // if (!isCurrentCompleted) {
-    //   state = state.copyWith(completeMessage: '짱이야, 해내버렸어요! 😍');
-    //   // 다른 태스크 완료 시에도 동작할 수 있도록 잠시 유지 후 초기화
-    //   Future.delayed(Duration(milliseconds: 2500), () {
-    //     state = state.copyWith(completeMessage: '');
-    //   });
-    // }
+  }) async {
+    final RepositoryResult<void> result = await _mainRepository.completeTask(
+      id: taskId,
+    );
+    switch (result) {
+      case SuccessRepositoryResult():
+        // 리스트 갱신
+        await getTodayPlans();
+        // 체크 안 함>체크 완료로 상태 변경 시 태스크 완료 토스트 노출되도록 message 변경
+        if (!isCurrentCompleted) {
+          state = state.copyWith(completeMessage: '짱이야, 해내버렸어요! 😍');
+          // 다른 태스크 완료 시에도 동작할 수 있도록 잠시 유지 후 초기화
+          Future.delayed(Duration(milliseconds: 2500), () {
+            state = state.copyWith(completeMessage: '');
+          });
+        }
+      case FailureRepositoryResult():
+        state = state.copyWith(
+          errorMessage: result.messages!.first,
+        );
+    }
   }
 
   // 길티프리 모드 사용 가능한지 판단
@@ -178,7 +151,6 @@ class MainViewModel extends StateNotifier<MainState> {
 }
 
 typedef OnCheckboxTap = void Function({
-  required int planIndex,
-  required int taskIndex,
+  required int taskId,
   required bool isCurrentCompleted,
 });

--- a/lib/ui/recovery/recovery_complete_view.dart
+++ b/lib/ui/recovery/recovery_complete_view.dart
@@ -60,11 +60,6 @@ class RecoveryCompleteView extends ConsumerWidget {
                 width: double.infinity,
                 child: PlanitButton(
                   onPressed: () {
-                    // 회복루틴 종료 시 오늘 날짜 저장
-                    service.setString(
-                      key: StorageKey.lastRecoveryRoutineDate,
-                      value: DateTime.now().toString(),
-                    );
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (context) => RootTab(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -552,6 +552,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  infinite_listview:
+    dependency: transitive
+    description:
+      name: infinite_listview
+      sha256: f6062c1720eb59be553dfa6b89813d3e8dd2f054538445aaa5edaddfa5195ce6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   intl:
     dependency: "direct main"
     description:
@@ -744,6 +752,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  numberpicker:
+    dependency: "direct main"
+    description:
+      name: numberpicker
+      sha256: "4c129154944b0f6b133e693f8749c3f8bfb67c4d07ef9dcab48b595c22d1f156"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   json_annotation: ^4.9.0
   smooth_page_indicator: ^1.2.1
   flutter_hooks: ^0.21.2
+  numberpicker: ^2.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 첫 달성 로직
   - 원래 화면만 만들어 두었었는데, 실제로 첫 달성 시에 자동으로 화면 뜨도록 구현했습니다
   - 하루 한 번만 떠야해서, 로컬에 달성 날짜를 저장했습니다
- 회복루틴 배너 수정 
   - 디자인 및 정책이 변경되어, UI 수정하고 천천히 루틴일 때는 항상 노출되도록 만들었습니다
- 열정 태스크 완료 로직 작성
   - 열정 태스크를 모두 완료하면 연속일이 노란색으로 표시될 수 있게 했어요
   - 단순하게 열정 태스크들을 모두 순회해서 완료 안 한 것이 있는지 확인하는 방식.. 효율적인 방법은 아닌데 다른 방법이 생각나지 않았네용
- 태스크 완료 바텀시트 추가
   - 태스크 완료 취소가 불가능하게 되어, 바텀시트를 통해 완료 처리할 수 있도록 만들었습니다
- 연속일 UI
   - 스크롤 되는 리스트를 어떻게 만들까 고민하다가 numberpicker라는 패키지를 사용해보았습니다
   - 역순이면 더 좋을텐데 이 부분은 어떻게 할 수 있을지 나중에 고민해볼게요

https://github.com/user-attachments/assets/d78f45ce-4e98-4d12-83dc-10e2bc3b025b


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- "거의" 완성인 이유는 연속일이 서버값 아니고 하드코딩이어서 그렇슴니당
- 작업량 한 번에 많아서 죄송합니다..
- DataSource랑 Repository 구조 위주로 봐주시면 감사드립니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 오늘의 할 일(플랜/태스크) 목록을 서버에서 불러오고, 태스크 완료 처리를 지원합니다.
  * 태스크 완료 시 확인 모달이 표시되어 실수 방지를 돕습니다.
  * 메인 상단에 NumberPicker 위젯이 추가되어 연속 완료일을 표시합니다.

* **UI/UX 개선**
  * 메인 플랜, 태스크, 배너 등 주요 컴포넌트의 데이터 구조가 개선되어 더 정교한 정보 제공이 가능합니다.
  * 리커버리 루틴 배너가 단순화되어 텍스트만 중앙에 노출됩니다.
  * 태스크 완료 상태 변화에 따른 자동 화면 전환 및 상태 업데이트가 추가되었습니다.

* **버그 수정 및 안정성**
  * 네트워크 오류 발생 시 사용자에게 안내 메시지가 표시됩니다.

* **기타**
  * 내부 데이터 모델 구조 및 상태 관리 방식이 개선되었습니다.
  * 불필요한 UI 요소 및 코드가 제거되고, 상태 관리 로직이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->