### PR TITLE
Pl 122/feat/chang/plan api connect

### DIFF
--- a/lib/data_source/plan/plan_data_source.dart
+++ b/lib/data_source/plan/plan_data_source.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planit/core/api_response.dart';
+import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
+import 'package:planit/service/network/dio_service.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'plan_data_source.g.dart';
+
+final Provider<PlanDataSource> planDataSourceProvider =
+    Provider<PlanDataSource>(
+  (ref) => PlanDataSource(ref.read(dioServiceProvider)),
+);
+
+@RestApi()
+abstract class PlanDataSource {
+  factory PlanDataSource(Dio dio) = _PlanDataSource;
+
+  @GET('/planit/plans')
+  Future<ApiResponse<PlanListResponseBody>> getPlanLists();
+
+  
+
+}

--- a/lib/data_source/plan/plan_data_source.dart
+++ b/lib/data_source/plan/plan_data_source.dart
@@ -1,7 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planit/core/api_response.dart';
+import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
+import 'package:planit/repository/plan/model/plan_detail_model.dart';
+import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/service/network/dio_service.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -19,6 +22,8 @@ abstract class PlanDataSource {
   @GET('/planit/plans')
   Future<ApiResponse<PlanListResponseBody>> getPlanLists();
 
-  
-
+  @GET('/planit/plans/{planId}')
+  Future<ApiResponse<PlanDetailResponseBody>> getPlanDetails(
+    @Path('planId') int planId,
+  );
 }

--- a/lib/data_source/plan/plan_data_source.g.dart
+++ b/lib/data_source/plan/plan_data_source.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plan_data_source.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _PlanDataSource implements PlanDataSource {
+  _PlanDataSource(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<ApiResponse<PlanListResponseBody>> getPlanLists() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<ApiResponse<PlanListResponseBody>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/planit/plans',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiResponse<PlanListResponseBody> _value;
+    try {
+      _value = ApiResponse<PlanListResponseBody>.fromJson(
+        _result.data!,
+        (json) => PlanListResponseBody.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/data_source/plan/plan_data_source.g.dart
+++ b/lib/data_source/plan/plan_data_source.g.dart
@@ -47,6 +47,36 @@ class _PlanDataSource implements PlanDataSource {
     return _value;
   }
 
+  @override
+  Future<ApiResponse<PlanDetailResponseBody>> getPlanDetails(int planId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<ApiResponse<PlanDetailResponseBody>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/planit/plans/${planId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ApiResponse<PlanDetailResponseBody> _value;
+    try {
+      _value = ApiResponse<PlanDetailResponseBody>.fromJson(
+        _result.data!,
+        (json) => PlanDetailResponseBody.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/data_source/plan/reponse_body/plan_detail_response_body.dart
+++ b/lib/data_source/plan/reponse_body/plan_detail_response_body.dart
@@ -1,0 +1,43 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'plan_detail_response_body.g.dart';
+
+@JsonSerializable()
+class PlanDetailResponseBody {
+  final int planId;
+  final String title;
+  final String icon;
+  final String motivation;
+  final List<TaskResponseBody> tasks;
+
+  PlanDetailResponseBody({
+    required this.planId,
+    required this.title,
+    required this.icon,
+    required this.motivation,
+    required this.tasks,
+  });
+
+  factory PlanDetailResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$PlanDetailResponseBodyFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PlanDetailResponseBodyToJson(this);
+}
+
+@JsonSerializable()
+class TaskResponseBody {
+  final int taskId;
+  final String taskType;
+  final String title;
+
+  TaskResponseBody({
+    required this.taskId,
+    required this.taskType,
+    required this.title,
+  });
+
+  factory TaskResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$TaskResponseBodyFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TaskResponseBodyToJson(this);
+}

--- a/lib/data_source/plan/reponse_body/plan_detail_response_body.g.dart
+++ b/lib/data_source/plan/reponse_body/plan_detail_response_body.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plan_detail_response_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PlanDetailResponseBody _$PlanDetailResponseBodyFromJson(
+        Map<String, dynamic> json) =>
+    PlanDetailResponseBody(
+      planId: (json['planId'] as num).toInt(),
+      title: json['title'] as String,
+      icon: json['icon'] as String,
+      motivation: json['motivation'] as String,
+      tasks: (json['tasks'] as List<dynamic>)
+          .map((e) => TaskResponseBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PlanDetailResponseBodyToJson(
+        PlanDetailResponseBody instance) =>
+    <String, dynamic>{
+      'planId': instance.planId,
+      'title': instance.title,
+      'icon': instance.icon,
+      'motivation': instance.motivation,
+      'tasks': instance.tasks,
+    };
+
+TaskResponseBody _$TaskResponseBodyFromJson(Map<String, dynamic> json) =>
+    TaskResponseBody(
+      taskId: (json['taskId'] as num).toInt(),
+      taskType: json['taskType'] as String,
+      title: json['title'] as String,
+    );
+
+Map<String, dynamic> _$TaskResponseBodyToJson(TaskResponseBody instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'taskType': instance.taskType,
+      'title': instance.title,
+    };

--- a/lib/data_source/plan/reponse_body/plan_response_body.dart
+++ b/lib/data_source/plan/reponse_body/plan_response_body.dart
@@ -1,0 +1,36 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:planit/data_source/main/reponse_body/today_tasks_response_body.dart';
+
+part 'plan_response_body.g.dart';
+
+@JsonSerializable()
+class PlanListResponseBody {
+  final String planStatus;
+  final List<PlanResponseBody> plans;
+
+  PlanListResponseBody({required this.planStatus, required this.plans});
+  factory PlanListResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$PlanListResponseBodyFromJson(json);
+  Map<String, dynamic> toJson() => _$PlanListResponseBodyToJson(this);
+}
+
+@JsonSerializable()
+class PlanResponseBody {
+  final int planId;
+  final String title;
+  final String icon;
+  final String motivation;
+  final int totalTasks;
+  final String dday;
+
+  PlanResponseBody(
+      {required this.planId,
+      required this.title,
+      required this.icon,
+      required this.motivation,
+      required this.totalTasks,
+      required this.dday});
+  factory PlanResponseBody.fromJson(Map<String, dynamic> json) =>
+      _$PlanResponseBodyFromJson(json);
+  Map<String, dynamic> toJson() => _$PlanResponseBodyToJson(this);
+}

--- a/lib/data_source/plan/reponse_body/plan_response_body.g.dart
+++ b/lib/data_source/plan/reponse_body/plan_response_body.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plan_response_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PlanListResponseBody _$PlanListResponseBodyFromJson(
+        Map<String, dynamic> json) =>
+    PlanListResponseBody(
+      planStatus: json['planStatus'] as String,
+      plans: (json['plans'] as List<dynamic>)
+          .map((e) => PlanResponseBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PlanListResponseBodyToJson(
+        PlanListResponseBody instance) =>
+    <String, dynamic>{
+      'planStatus': instance.planStatus,
+      'plans': instance.plans,
+    };
+
+PlanResponseBody _$PlanResponseBodyFromJson(Map<String, dynamic> json) =>
+    PlanResponseBody(
+      planId: (json['planId'] as num).toInt(),
+      title: json['title'] as String,
+      icon: json['icon'] as String,
+      motivation: json['motivation'] as String,
+      totalTasks: (json['totalTasks'] as num).toInt(),
+      dday: json['dday'] as String,
+    );
+
+Map<String, dynamic> _$PlanResponseBodyToJson(PlanResponseBody instance) =>
+    <String, dynamic>{
+      'planId': instance.planId,
+      'title': instance.title,
+      'icon': instance.icon,
+      'motivation': instance.motivation,
+      'totalTasks': instance.totalTasks,
+      'dday': instance.dday,
+    };

--- a/lib/repository/plan/model/plan_detail_model.dart
+++ b/lib/repository/plan/model/plan_detail_model.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/repository/plan/model/task_model.dart';
 import 'package:planit/ui/main/component/task_widget.dart';
 
@@ -16,4 +17,13 @@ class PlanDetailModel {
     required this.motivation,
     required this.tasks,
   });
+  factory PlanDetailModel.fromResponse(PlanDetailResponseBody response) {
+    return PlanDetailModel(
+      planId: response.planId,
+      title: response.title,
+      icon: response.icon,
+      motivation: response.motivation,
+      tasks: response.tasks.map((e) => TaskModel.fromResponse(e)).toList(),
+    );
+  }
 }

--- a/lib/repository/plan/model/plan_model.dart
+++ b/lib/repository/plan/model/plan_model.dart
@@ -21,12 +21,12 @@ class PlanModel {
 
   factory PlanModel.fromResponse(PlanResponseBody response) {
     return PlanModel(
-      planId: response.planId,
-      title: response.title,
-      icon: response.icon,
-      motivation: response.motivation,
-      totalTask: response.totalTasks,
-      dDay: response.dday,
-    );
+        planId: response.planId,
+        title: response.title,
+        icon: response.icon,
+        motivation: response.motivation,
+        totalTask: response.totalTasks,
+        dDay: response.dday,
+        planStatus: 'IN_PROGRESS');
   }
 }

--- a/lib/repository/plan/model/plan_model.dart
+++ b/lib/repository/plan/model/plan_model.dart
@@ -1,3 +1,4 @@
+import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
 import 'package:planit/repository/plan/model/task_model.dart';
 
 class PlanModel {
@@ -5,7 +6,7 @@ class PlanModel {
   final String title;
   final String motivation;
   final int totalTask;
-  final int? dDay;
+  final String? dDay;
   final String icon;
   final String? planStatus;
 
@@ -17,4 +18,15 @@ class PlanModel {
       this.dDay,
       required this.icon,
       this.planStatus});
+
+  factory PlanModel.fromResponse(PlanResponseBody response) {
+    return PlanModel(
+      planId: response.planId,
+      title: response.title,
+      icon: response.icon,
+      motivation: response.motivation,
+      totalTask: response.totalTasks,
+      dDay: response.dday,
+    );
+  }
 }

--- a/lib/repository/plan/model/task_model.dart
+++ b/lib/repository/plan/model/task_model.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/repository/plan/model/task_model.dart';
 
 class TaskModel {
@@ -11,4 +12,11 @@ class TaskModel {
     required this.taskType,
     required this.title,
   });
+  factory TaskModel.fromResponse(TaskResponseBody response) {
+    return TaskModel(
+      taskId: response.taskId,
+      taskType: response.taskType,
+      title: response.title,
+    );
+  }
 }

--- a/lib/repository/plan/plan_repository.dart
+++ b/lib/repository/plan/plan_repository.dart
@@ -40,6 +40,8 @@ class PlanRepository {
       }
     } on DioException catch (e) {
       return FailureRepositoryResult(error: e, messages: [networkErrorMsg]);
+    } catch (e) {
+      return FailureRepositoryResult(error: e, messages: [networkErrorMsg]);
     }
   }
 
@@ -63,6 +65,8 @@ class PlanRepository {
         error: e,
         messages: [networkErrorMsg],
       );
+    } catch (e) {
+      return FailureRepositoryResult(error: e, messages: [networkErrorMsg]);
     }
   }
 }

--- a/lib/repository/plan/plan_repository.dart
+++ b/lib/repository/plan/plan_repository.dart
@@ -1,6 +1,11 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/rendering.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:planit/core/api_response.dart';
+import 'package:planit/core/error_message.dart';
 import 'package:planit/core/repository_result.dart';
+import 'package:planit/data_source/plan/plan_data_source.dart';
+import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
 import 'package:planit/repository/plan/model/plan_detail_model.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/repository/plan/model/task_model.dart';
@@ -8,134 +13,38 @@ import 'package:planit/ui/common/assets.dart';
 
 final AutoDisposeProvider<PlanRepository> planRepositoryProvider =
     Provider.autoDispose<PlanRepository>(
-  (ref) => PlanRepository(),
+  (ref) => PlanRepository(planDataSource: ref.read(planDataSourceProvider)),
 );
 
 class PlanRepository {
-  const PlanRepository();
+  final PlanDataSource _planDataSource;
 
-Future<RepositoryResult<List<PlanModel>>> getActivePlanList() async {
-  return SuccessRepositoryResult(data: [
-    PlanModel(
-      planId: 0,
-      title: 'TOEIC 고득점',
-      motivation: '매일 조금씩 나아지는..',
-      totalTask: 5,
-      dDay: 12,
-      icon: Assets.planet1,
-    ),
-    PlanModel(
-      planId: 1,
-      title: '독서 습관',
-      motivation: '독서 습관을 기르자',
-      totalTask: 2,
-      dDay: 7,
-      icon: Assets.planet3,
-    ),
-    PlanModel(
-      planId: 2,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: Assets.planet6,
-    ),
-    PlanModel(
-      planId: 2,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 2,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 2,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-  ]);
-}
+  const PlanRepository({
+    required PlanDataSource planDataSource,
+  }) : _planDataSource = planDataSource;
 
-Future<RepositoryResult<List<PlanModel>>> getPausePlanList() async {
-  return SuccessRepositoryResult(data: [
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: Assets.planet1,
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-    PlanModel(
-      planId: 5,
-      title: '헬스장 꾸준히 가기',
-      motivation: '작심삼일 10번이면 한달이다',
-      totalTask: 3,
-      dDay: 20,
-      icon: 'assets/planets/planet6.svg',
-    ),
-  ]);
-}
+  Future<RepositoryResult<List<PlanModel>>> getActivePlanList() async {
+    try {
+      final ApiResponse<PlanListResponseBody> result =
+          await _planDataSource.getPlanLists();
 
+      final data = result.data;
+
+      if (data.planStatus == 'IN_PROGRESS') {
+        final plans = data.plans;
+        final models = plans.map((e) => PlanModel.fromResponse(e)).toList();
+        return SuccessRepositoryResult(data: models);
+      } else {
+        return SuccessRepositoryResult(data: []);
+      }
+    } on DioException catch (e) {
+      return FailureRepositoryResult(error: e, messages: [networkErrorMsg]);
+    }
+  }
+//
+  Future<RepositoryResult<List<PlanModel>>> getPausePlanList() async {
+    return SuccessRepositoryResult(data: []);
+  }
 
   Future<RepositoryResult<PlanDetailModel>> getPlanDetailByPlanId(
       int planId) async {

--- a/lib/repository/plan/plan_repository.dart
+++ b/lib/repository/plan/plan_repository.dart
@@ -5,6 +5,7 @@ import 'package:planit/core/api_response.dart';
 import 'package:planit/core/error_message.dart';
 import 'package:planit/core/repository_result.dart';
 import 'package:planit/data_source/plan/plan_data_source.dart';
+import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
 import 'package:planit/repository/plan/model/plan_detail_model.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
@@ -41,25 +42,27 @@ class PlanRepository {
       return FailureRepositoryResult(error: e, messages: [networkErrorMsg]);
     }
   }
-//
+
   Future<RepositoryResult<List<PlanModel>>> getPausePlanList() async {
     return SuccessRepositoryResult(data: []);
   }
 
   Future<RepositoryResult<PlanDetailModel>> getPlanDetailByPlanId(
       int planId) async {
-    return SuccessRepositoryResult(
-      data: PlanDetailModel(
-        planId: 0,
-        title: '다이어트',
-        icon: Assets.planet1,
-        motivation: '매일 조금씩 , 꾸준히 나아가자',
-        tasks: [
-          TaskModel(taskId: 0, taskType: 'ALL', title: '아침 식단 기록하기'),
-          TaskModel(taskId: 0, taskType: 'ALL', title: '30분 산책하기'),
-          TaskModel(taskId: 0, taskType: 'ALL', title: '저녁 과식 피하기'),
-        ],
-      ),
-    );
+    try {
+      final ApiResponse<PlanDetailResponseBody> result =
+          await _planDataSource.getPlanDetails(planId);
+      final data = result.data;
+      final model = PlanDetailModel.fromResponse(data);
+
+      return SuccessRepositoryResult(
+        data: model,
+      );
+    } on DioException catch (e) {
+      return FailureRepositoryResult(
+        error: e,
+        messages: [networkErrorMsg],
+      );
+    }
   }
 }

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -28,150 +28,228 @@ class PlanView extends HookConsumerWidget {
       });
       return null;
     }, []);
-
-    return DefaultLayout(
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            AppBar(
-              toolbarHeight: 92,
-              backgroundColor: PlanitColors.white02,
-              automaticallyImplyLeading: false,
-              title: PlanitText('내 플랜', style: PlanitTypos.title2),
-              actions: [
-                Padding(
-                  padding: EdgeInsetsGeometry.symmetric(horizontal: 20),
-                  child: PlanitButton(
-                      onPressed: () {
-                        Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => PlanCreateView(),
-                            ));
-                      },
-                      buttonColor: PlanitButtonColor.black,
-                      buttonSize: PlanitButtonSize.small,
-                      label: '+ 새 플랜'),
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 20),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText('진행 중인 플랜',
-                    style: PlanitTypos.body2
-                        .copyWith(color: PlanitColors.black01)),
+    if (state.activePlans.isEmpty) {
+      return DefaultLayout(
+          child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppBar(
+            toolbarHeight: 92,
+            backgroundColor: PlanitColors.white02,
+            automaticallyImplyLeading: false,
+            title: PlanitText('내 플랜', style: PlanitTypos.title2),
+            actions: [
+              Padding(
+                padding: EdgeInsetsGeometry.symmetric(horizontal: 20),
+                child: PlanitButton(
+                    onPressed: () {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => PlanCreateView(),
+                          ));
+                    },
+                    buttonColor: PlanitButtonColor.black,
+                    buttonSize: PlanitButtonSize.small,
+                    label: '+ 새 플랜'),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: PlanitText(
+                '템플릿',
+                style: PlanitTypos.body2.copyWith(color: PlanitColors.black01),
               ),
             ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 12),
-              child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: state.activePlans.length > 5
-                      ? 5
-                      : state.activePlans.length,
-                  itemBuilder: (context, index) {
-                    final item = state.activePlans[index];
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: PlanListCard(
-                        plan: item,
-                      ),
-                    );
-                  }),
-            ),
-            state.activePlans.length > 5
-                ? Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20)
-                        .copyWith(top: 12),
-                    child: SizedBox(
-                      width: double.infinity,
-                      child: PlanitButton(
-                          onPressed: () {
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => PlanViewAll(
-                                          planList: state.activePlans,
-                                          isActive: true,
-                                        )));
-                          },
-                          buttonColor: PlanitButtonColor.white,
-                          buttonSize: PlanitButtonSize.large,
-                          label: '플랜 전체보기'),
-                    ),
-                  )
-                : SizedBox(),
-            Padding(
-              padding: const EdgeInsets.only(top: 20),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText('잠시 중단한 플랜',
-                    style: PlanitTypos.body2
-                        .copyWith(color: PlanitColors.black01)),
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 12),
-              child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount:
-                      state.pausePlans.length > 5 ? 5 : state.pausePlans.length,
-                  itemBuilder: (context, index) {
-                    final item = state.pausePlans[index];
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: PlanListCard(
-                        plan: item,
-                      ),
-                    );
-                  }),
-            ),
-            state.pausePlans.length > 5
-                ? Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20)
-                        .copyWith(top: 12),
-                    child: SizedBox(
-                      width: double.infinity,
-                      child: PlanitButton(
-                          onPressed: () {
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => PlanViewAll(
-                                          planList: state.pausePlans,
-                                          isActive: false,
-                                        )));
-                          },
-                          buttonColor: PlanitButtonColor.white,
-                          buttonSize: PlanitButtonSize.large,
-                          label: '플랜 전체보기'),
-                    ),
-                  )
-                : SizedBox(),
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText(
-                  '템플릿',
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 20),
+            child: TemplateList(),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 20),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: PlanitText('진행 중인 플랜',
                   style:
-                      PlanitTypos.body2.copyWith(color: PlanitColors.black01),
-                ),
+                      PlanitTypos.body2.copyWith(color: PlanitColors.black01)),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 20,
+                children: [
+                  Text(
+                    '아직 플랜이\n존재하지 않아요!',
+                    style: PlanitTypos.body3.copyWith(
+                      color: PlanitColors.black03,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  Text(
+                    '새로 플랜을 만들어 볼까요?',
+                    style: PlanitTypos.caption.copyWith(
+                      color: PlanitColors.black03,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 20),
-              child: TemplateList(),
-            )
-          ],
+          ),
+        ],
+      ));
+    } else {
+      return DefaultLayout(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              AppBar(
+                toolbarHeight: 92,
+                backgroundColor: PlanitColors.white02,
+                automaticallyImplyLeading: false,
+                title: PlanitText('내 플랜', style: PlanitTypos.title2),
+                actions: [
+                  Padding(
+                    padding: EdgeInsetsGeometry.symmetric(horizontal: 20),
+                    child: PlanitButton(
+                        onPressed: () {
+                          Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => PlanCreateView(),
+                              ));
+                        },
+                        buttonColor: PlanitButtonColor.black,
+                        buttonSize: PlanitButtonSize.small,
+                        label: '+ 새 플랜'),
+                  ),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: PlanitText('진행 중인 플랜',
+                      style: PlanitTypos.body2
+                          .copyWith(color: PlanitColors.black01)),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20)
+                    .copyWith(top: 12),
+                child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: state.activePlans.length > 5
+                        ? 5
+                        : state.activePlans.length,
+                    itemBuilder: (context, index) {
+                      final item = state.activePlans[index];
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: PlanListCard(
+                          plan: item,
+                        ),
+                      );
+                    }),
+              ),
+              state.activePlans.length > 5
+                  ? Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20)
+                          .copyWith(top: 12),
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: PlanitButton(
+                            onPressed: () {
+                              Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => PlanViewAll(
+                                            planList: state.activePlans,
+                                            isActive: true,
+                                          )));
+                            },
+                            buttonColor: PlanitButtonColor.white,
+                            buttonSize: PlanitButtonSize.large,
+                            label: '플랜 전체보기'),
+                      ),
+                    )
+                  : SizedBox(),
+              Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: PlanitText('잠시 중단한 플랜',
+                      style: PlanitTypos.body2
+                          .copyWith(color: PlanitColors.black01)),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20)
+                    .copyWith(top: 12),
+                child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: state.pausePlans.length > 5
+                        ? 5
+                        : state.pausePlans.length,
+                    itemBuilder: (context, index) {
+                      final item = state.pausePlans[index];
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: PlanListCard(
+                          plan: item,
+                        ),
+                      );
+                    }),
+              ),
+              state.pausePlans.length > 5
+                  ? Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20)
+                          .copyWith(top: 12),
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: PlanitButton(
+                            onPressed: () {
+                              Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => PlanViewAll(
+                                            planList: state.pausePlans,
+                                            isActive: false,
+                                          )));
+                            },
+                            buttonColor: PlanitButtonColor.white,
+                            buttonSize: PlanitButtonSize.large,
+                            label: '플랜 전체보기'),
+                      ),
+                    )
+                  : SizedBox(),
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: PlanitText(
+                    '템플릿',
+                    style:
+                        PlanitTypos.body2.copyWith(color: PlanitColors.black01),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: TemplateList(),
+              )
+            ],
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
 }
 

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -33,28 +33,7 @@ class PlanView extends HookConsumerWidget {
           child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          AppBar(
-            toolbarHeight: 92,
-            backgroundColor: PlanitColors.white02,
-            automaticallyImplyLeading: false,
-            title: PlanitText('내 플랜', style: PlanitTypos.title2),
-            actions: [
-              Padding(
-                padding: EdgeInsetsGeometry.symmetric(horizontal: 20),
-                child: PlanitButton(
-                    onPressed: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => PlanCreateView(),
-                          ));
-                    },
-                    buttonColor: PlanitButtonColor.black,
-                    buttonSize: PlanitButtonSize.small,
-                    label: '+ 새 플랜'),
-              ),
-            ],
-          ),
+          BuildAppBar(),
           Padding(
             padding: const EdgeInsets.only(top: 8),
             child: Padding(
@@ -110,28 +89,7 @@ class PlanView extends HookConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              AppBar(
-                toolbarHeight: 92,
-                backgroundColor: PlanitColors.white02,
-                automaticallyImplyLeading: false,
-                title: PlanitText('내 플랜', style: PlanitTypos.title2),
-                actions: [
-                  Padding(
-                    padding: EdgeInsetsGeometry.symmetric(horizontal: 20),
-                    child: PlanitButton(
-                        onPressed: () {
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => PlanCreateView(),
-                              ));
-                        },
-                        buttonColor: PlanitButtonColor.black,
-                        buttonSize: PlanitButtonSize.small,
-                        label: '+ 새 플랜'),
-                  ),
-                ],
-              ),
+              BuildAppBar(),
               Padding(
                 padding: const EdgeInsets.only(top: 20),
                 child: Padding(
@@ -388,6 +346,38 @@ class _PlanViewAllState extends State<PlanViewAll> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class BuildAppBar extends StatelessWidget {
+  const BuildAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      toolbarHeight: 92,
+      backgroundColor: PlanitColors.white02,
+      automaticallyImplyLeading: false,
+      title: PlanitText('내 플랜', style: PlanitTypos.title2),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: PlanitButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => PlanCreateView(),
+                ),
+              );
+            },
+            buttonColor: PlanitButtonColor.black,
+            buttonSize: PlanitButtonSize.small,
+            label: '+ 새 플랜',
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 플랜 Main 에서 진행중인 플랜 받아오는 걸 정의했습니다. 
    - 서버에서 플랜을 줄때, planStatus 와 plans를 같이줘서 planStatus가 IN_PROGRESS 인 경우에만 plans를 받아오게 했습니다
- 진행중인 플랜이 없을 때 나올 화면을 구현했습니다.
    - 진행중인 플랜이 없을때, 템플릿 위치가 아래에서 위쪽으로 바뀌고 중단한 플랜 리스트가 없어져서  view에 DefalutLayout을 하나 더 정의했습니다( activePlans == isEmpty일때 사용)

- 플랜 Detail API를 정의했습니다

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 메인에서 API 연동한거 참고해서 따라 해봤는데 이게 맞는지 잘 모르겠네요,,,
- Swagger 로는 잘 불러오는데 BASEURL 설정해서 테스트하면 앱으로는 못 불러오네요 혹시 제가 놓친게 잇을까요 ,,,
- response 를 따로 만드는 이유가 있나요??  planDetail에서 API 연동할때 model 이랑 response 안에 들어있는 내용이 같아서  model이 있는데도 response를 따로 정의해야하나 싶어서 질문해봅니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 플랜 목록 및 상세 정보를 실제 API에서 불러오는 기능이 추가되었습니다.
  * 플랜, 태스크 관련 데이터 모델이 추가되어 서버 응답을 앱에서 활용할 수 있습니다.

* **리팩터**
  * 기존에 하드코딩된 플랜 데이터가 실제 네트워크 데이터를 사용하도록 변경되었습니다.
  * 플랜 상세, 플랜 목록, 태스크 모델이 서버 응답 객체로부터 변환될 수 있도록 개선되었습니다.

* **UI 개선**
  * 플랜이 없을 때와 있을 때의 화면이 구분되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->