### PR TITLE
[Feat] 길티프리 완성

### DIFF
--- a/lib/repository/guilty_free/guilty_free_repository.dart
+++ b/lib/repository/guilty_free/guilty_free_repository.dart
@@ -44,6 +44,11 @@ class GuiltyFreeRepository {
     try {
       final ApiResponse<GuiltyFreeDateResponseBody> result =
           await _guiltyFreeDataSource.getGuiltyFreeDate();
+      // 성공 시 로컬에 저장
+      _planitStorageService.setString(
+        key: StorageKey.lastGuiltyFreeDate,
+        value: result.data.activatedAt,
+      );
       final data = GuiltyFreeDateModel.fromResponse(result.data);
       return SuccessRepositoryResult(data: data);
     } on DioException catch (e) {

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -5,6 +5,7 @@ import 'package:planit/routes/redirect_notifier.dart';
 import 'package:planit/ui/common/const/web_view_params.dart';
 import 'package:planit/ui/common/view/planit_web_view.dart';
 import 'package:planit/ui/common/view/root_tab.dart';
+import 'package:planit/ui/guilty_free/end/guilty_free_end_view.dart';
 import 'package:planit/ui/guilty_free/ing/history/guilty_free_history_view.dart';
 import 'package:planit/ui/guilty_free/start/view/guilty_free_blocked_view.dart';
 import 'package:planit/ui/guilty_free/start/view/guilty_free_intro_view.dart';
@@ -206,6 +207,14 @@ class AppRouter {
             ),
           ),
         ],
+      ),
+      // 길티프리 종료 화면
+      GoRoute(
+        path: '/guilty-end',
+        name: GuiltyFreeEndView.routeName,
+        pageBuilder: (context, state) => NoTransitionPage(
+          child: GuiltyFreeEndView(),
+        ),
       ),
     ],
   );

--- a/lib/service/app/app_service.dart
+++ b/lib/service/app/app_service.dart
@@ -101,7 +101,16 @@ class AppService extends StateNotifier<AppState> {
       );
       final DateTime? lastDate = stringToDateTime(lastDateString);
 
-      if (lastDate != null && lastDate.isBefore(today) && today.hour >= 6) {
+      // 시간을 포함하고 isBefore을 사용하면, 같은 날이어도 전날 취급되어
+      // 시간 제외하고 날짜만 비교하도록 변경
+      final DateTime todayDate = DateTime(today.year, today.month, today.day);
+      final DateTime lastDateOnly = DateTime(
+        lastDate!.year,
+        lastDate.month,
+        lastDate.day,
+      );
+
+      if (lastDateOnly.isBefore(todayDate) && today.hour >= 6) {
         status = GuiltyFreeStatus.end;
         _planitStorageService.setString(
           key: StorageKey.guiltyFreeStatus,

--- a/lib/ui/guilty_free/end/guilty_free_end_view.dart
+++ b/lib/ui/guilty_free/end/guilty_free_end_view.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+import 'package:planit/core/guilty_free_status.dart';
+import 'package:planit/service/storage/planit_storage_service.dart';
+import 'package:planit/service/storage/storage_key.dart';
+import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/theme/planit_typos.dart';
+import 'package:planit/ui/common/comopnent/planit_button.dart';
+import 'package:planit/ui/common/comopnent/planit_text.dart';
+import 'package:planit/ui/common/const/planit_button_style.dart';
+import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
+
+import '../../common/assets.dart';
+
+class GuiltyFreeEndView extends ConsumerWidget {
+  static String get routeName => 'guilty-end';
+
+  const GuiltyFreeEndView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Size deviceSize = MediaQuery.of(context).size;
+
+    final PlanitStorageService storageService = ref.read(
+      planitStorageServiceProvider,
+    );
+
+    return DefaultLayout(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Padding(
+            padding: EdgeInsetsGeometry.only(bottom: 120.0),
+            child: SvgPicture.asset(
+              Assets.mascotRestarting,
+              width: deviceSize.width,
+            ),
+          ),
+          Column(
+            children: [
+              Spacer(),
+              PlanitText(
+                '오늘도 첫 걸음을 떼었어요',
+                style: PlanitTypos.title1.copyWith(
+                  color: PlanitColors.black01,
+                ),
+              ),
+              // 이미지 보이도록 공간 넓게 할당
+              Spacer(flex: 3),
+              PlanitText(
+                '이제 해야 할 일로 부드럽게 연결해볼게요.\n같이 해볼까요? 😄',
+                textAlign: TextAlign.center,
+                style: PlanitTypos.body2.copyWith(
+                  color: PlanitColors.black02,
+                ),
+              ),
+              Spacer(),
+              Container(
+                margin: EdgeInsetsGeometry.only(
+                  left: 20.0,
+                  right: 20.0,
+                  bottom: 40.0,
+                ),
+                width: double.infinity,
+                child: PlanitButton(
+                  onPressed: () {
+                    // 버튼 클릭 시 GuiltyFreeStatus가 none으로 저장되어,
+                    // 길티프리 관련 액션 수행되지 않게 함
+                    storageService.setString(
+                      key: StorageKey.guiltyFreeStatus,
+                      value: GuiltyFreeStatus.none.name,
+                    );
+                    context.goNamed(RootTab.routeName);
+                  },
+                  buttonColor: PlanitButtonColor.black,
+                  buttonSize: PlanitButtonSize.large,
+                  label: '오늘도 한 발짝 나아가기',
+                ),
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/guilty_free/ing/guilty_free_ing_view_model.dart
+++ b/lib/ui/guilty_free/ing/guilty_free_ing_view_model.dart
@@ -26,7 +26,7 @@ class GuiltyFreeIngViewModel extends StateNotifier<GuiltyFreeIngState> {
       state = state.copyWith(loadingStatus: LoadingStatus.loading);
     }
 
-    final RepositoryResult<void> result = await _guiltyFreeRepository.endGuiltyFree();
+    final RepositoryResult<void> result = _guiltyFreeRepository.endGuiltyFree();
 
     switch (result) {
       case SuccessRepositoryResult<void>():

--- a/lib/ui/guilty_free/ing/history/guilty_free_history_view.dart
+++ b/lib/ui/guilty_free/ing/history/guilty_free_history_view.dart
@@ -140,6 +140,7 @@ class _Advice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       spacing: 12.0,
       children: [
         PlanitText(

--- a/lib/ui/guilty_free/start/view/guilty_free_blocked_view.dart
+++ b/lib/ui/guilty_free/start/view/guilty_free_blocked_view.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
-import 'package:planit/ui/main/main_view.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
 
 class GuiltyFreeBlockedView extends StatelessWidget {
   static String get routeName => 'guilty-blocked';
@@ -76,11 +77,7 @@ class GuiltyFreeBlockedView extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 child: PlanitButton(
-                  onPressed: () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => MainView(),
-                    ),
-                  ),
+                  onPressed: () => context.goNamed(RootTab.routeName),
                   buttonColor: PlanitButtonColor.black,
                   buttonSize: PlanitButtonSize.large,
                   label: '오늘도 한 걸음 하기',

--- a/lib/ui/guilty_free/start/view/guilty_free_reason_view.dart
+++ b/lib/ui/guilty_free/start/view/guilty_free_reason_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:planit/core/loading_status.dart';
 import 'package:planit/ui/common/assets.dart';
 import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/guilty_free/start/guilty_free_start_state.dart';
@@ -15,7 +14,6 @@ import '../../../common/comopnent/planit_text.dart';
 import '../../../common/const/planit_button_style.dart';
 import '../../../common/view/default_layout.dart';
 import '../../const/guilty_free_reasons.dart';
-import '../../ing/guilty_free_ing_view.dart';
 
 class GuiltyFreeReasonView extends HookConsumerWidget {
   static String get routeName => 'guilty-reason';

--- a/lib/ui/splash_view.dart
+++ b/lib/ui/splash_view.dart
@@ -12,8 +12,8 @@ import 'package:planit/ui/common/assets.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:planit/ui/common/view/root_tab.dart';
+import 'package:planit/ui/guilty_free/end/guilty_free_end_view.dart';
 import 'package:planit/ui/onboarding/onboarding_view.dart';
-import 'package:planit/ui/recovery/recovery_complete_view.dart';
 
 class SplashView extends ConsumerStatefulWidget {
   static String get routeName => 'splash';
@@ -50,7 +50,7 @@ class _SplashViewState extends ConsumerState<SplashView> {
           // 그렇지 않다면 메인으로
           context.goNamed(
             isGuiltyFreeFinished
-                ? RecoveryCompleteView.routeName
+                ? GuiltyFreeEndView.routeName
                 : RootTab.routeName,
           );
         } else {

--- a/lib/utils/date_time.dart
+++ b/lib/utils/date_time.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
 
 // String을 DateTime으로 변환
@@ -6,7 +5,6 @@ DateTime? stringToDateTime(String dateString) {
   try {
     return DateFormat('yyyy-MM-dd HH:mm:ss.SSS').parse(dateString);
   } catch (e) {
-    debugPrint('String to DateTime 실패: $e');
-    return null;
+    return DateTime.tryParse(dateString);
   }
 }

--- a/lib/utils/date_time.dart
+++ b/lib/utils/date_time.dart
@@ -8,3 +8,7 @@ DateTime? stringToDateTime(String dateString) {
     return DateTime.tryParse(dateString);
   }
 }
+
+String dashDateToDot(String dateString) {
+  return dateString.replaceAll('-', '.');
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 길티프리 사용내역 UI 수정
    - API 연동하려 했는데 이미 되어있던 것
- 로그인 시 서버에서 길티프리 마지막 사용일 불러와 저장
- 길티프리 완료 화면에서 로컬의 GuiltyFreeStatus를 end로 변경하여, 해당 화면 한 번만 노출되도록
- 길티프리 제발 완성!! 보이는 오류는 다 고쳤고 더이상의 오류가 없길 바랍니다
- 길티프리 자동 해제를 위한 날짜 계산 로직에 오류가 있어 수정
   - isBefore로 이전 날짜인지 계산하였는데, 기존에는 시각이 포함되어있어 하루가 안 지나도 이전 날짜 취급당했음
   - 그래서 시각을 빼고 비교하게 만듦
  
<br>

- 이렇게 해서 길티프리를 완성하였고 추가 오류가 없길 바랍니다 제랍ㄹ
<img width="256" height="300" alt="image" src="https://github.com/user-attachments/assets/a86af6c0-08b2-4924-bffd-3b22d9a6fa3b" />


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 감사합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 길티프리 종료 화면이 추가되어, 길티프리 플로우 완료 시 새로운 종료 화면이 표시됩니다.
  * 날짜 문자열의 하이픈(-)을 점(.)으로 변환하는 기능이 추가되었습니다.

* **버그 수정**
  * 날짜 비교 로직이 개선되어, 시간에 관계없이 올바른 날짜 기준으로 상태가 변경됩니다.
  * 날짜 파싱 실패 시 예외 처리가 보완되었습니다.

* **UI/UX 개선**
  * 일부 화면에서 버튼 클릭 시 이동 경로가 변경되어 더 자연스러운 네비게이션을 제공합니다.
  * 조언 히스토리 화면의 정렬이 개선되었습니다.
  * 길티프리 종료 시 안내 메시지와 버튼이 추가되었습니다.

* **기타**
  * 불필요한 import가 정리되었습니다.
  * 로그인 시 마지막 길티프리 사용일을 동기화하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->