### PR TITLE
Pl 117/feat/chang/plan gorouter setting

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/routes/redirect_notifier.dart';
 import 'package:planit/ui/common/const/web_view_params.dart';
 import 'package:planit/ui/common/view/planit_web_view.dart';
@@ -11,6 +12,12 @@ import 'package:planit/ui/mypage/view/mypage_account_view.dart';
 import 'package:planit/ui/mypage/view/mypage_customer_view.dart';
 import 'package:planit/ui/mypage/view/mypage_view.dart';
 import 'package:planit/ui/onboarding/onboarding_view.dart';
+import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
+import 'package:planit/ui/plan/plan_detail/plan_detail_view.dart';
+import 'package:planit/ui/plan/plan_main/plan_view.dart';
+import 'package:planit/ui/plan/plan_template/plan_teamplate_view.dart';
+import 'package:planit/ui/plan/plan_template/plan_template.dart';
+import 'package:planit/ui/plan/plan_template/plan_template_detail_view.dart';
 import 'package:planit/ui/splash_view.dart';
 
 import 'app_router_interceptor.dart';
@@ -78,6 +85,75 @@ class AppRouter {
                   child: MypageAccountView(),
                 ),
               ),
+            ],
+          ),
+          GoRoute(
+            path: 'plan',
+            name: PlanView.routeName,
+            pageBuilder: (context, state) => NoTransitionPage(
+              child: PlanView(), // Plan 목록이나 메인
+            ),
+            routes: [
+              GoRoute(
+                path: 'all/:isActive',
+                name: PlanViewAll.routeName,
+                pageBuilder: (context, state) {
+                  final planList = state.extra as List<PlanModel>? ?? [];
+                  final isActiveStr = state.pathParameters['isActive']!;
+                  final isActive = bool.parse(isActiveStr);
+                  return NoTransitionPage(
+                      child: PlanViewAll(
+                    planList: planList,
+                    isActive: isActive,
+                  ));
+                },
+              ),
+              GoRoute(
+                  path: 'detail/:planStatus/:planId',
+                  name: 'plan_detail',
+                  pageBuilder: (context, state) {
+                    final planStatus = state.pathParameters['planStatus']!;
+                    final planIdStr = state.pathParameters['planId']!;
+                    final planId = int.parse(planIdStr);
+                    return NoTransitionPage(
+                      child: PlanDetailView(
+                        planId: planId,
+                        planStatus: planStatus,
+                      ),
+                    );
+                  }),
+              GoRoute(
+                path: 'create',
+                name: PlanCreateView.routeName,
+                pageBuilder: (context, state) {
+                  final planIdStr = state.uri.queryParameters['planId'];
+                  final planId =
+                      planIdStr != null ? int.tryParse(planIdStr) : null;
+                  return NoTransitionPage(
+                    child: PlanCreateView(planId: planId), // null 허용
+                  );
+                },
+              ),
+              GoRoute(
+                  path: 'template/:templateName',
+                  name: PlanTeamplateView.routeName,
+                  pageBuilder: (context, state) {
+                    final templateName = state.pathParameters['templateName']!;
+                    return NoTransitionPage(
+                      child: PlanTeamplateView(
+                        templateName: templateName,
+                      ),
+                    );
+                  }),
+              GoRoute(
+                  path: 'templateDetail',
+                  name: PlanTemplateDetailView.routeName,
+                  pageBuilder: (context, state) {
+                    final templateDetail = state.extra as PlanTemplateDetail;
+                    return NoTransitionPage(
+                        child: PlanTemplateDetailView(
+                            templateDetai: templateDetail));
+                  }),
             ],
           ),
         ],

--- a/lib/ui/plan/component/plan_list_card.dart
+++ b/lib/ui/plan/component/plan_list_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_chip.dart';
@@ -14,24 +15,18 @@ class PlanListCard extends StatelessWidget {
   final PlanModel plan;
   final String planStatus;
 
-  const PlanListCard({
-    super.key,
-    required this.plan,
-    required this.planStatus
-  });
+  const PlanListCard({super.key, required this.plan, required this.planStatus});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => PlanDetailView(
-              planId: plan.planId,
-              planStatus : planStatus
-            ),
-          ),
+        context.pushNamed(
+          'plan_detail',
+          pathParameters: {
+            'planId': plan.planId.toString(),
+            'planStatus': planStatus, // 예: 'active' or 'completed'
+          },
         );
       },
       child: Container(

--- a/lib/ui/plan/component/template_detail_card.dart
+++ b/lib/ui/plan/component/template_detail_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/repository/task/model/task_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
@@ -24,12 +25,8 @@ class TemplateDetailCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: GestureDetector(
         onTap: () {
-          Navigator.push(
-              context,
-              MaterialPageRoute(
-                  builder: (context) => PlanTemplateDetailView(
-                        templateDetai: templateDetail,
-                      )));
+          context.pushNamed(PlanTemplateDetailView.routeName,
+              extra: templateDetail);
         },
         child: Container(
           decoration: BoxDecoration(

--- a/lib/ui/plan/component/template_list.dart
+++ b/lib/ui/plan/component/template_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/ui/plan/plan_template/plan_teamplate_view.dart';
 
 class TemplateList extends StatelessWidget {
@@ -35,13 +36,9 @@ class TemplateList extends StatelessWidget {
           itemBuilder: (context, index) {
             return GestureDetector(
               onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => PlanTeamplateView(
-                      templateName: templateNames[index], // 여기서 이름 전달
-                    ),
-                  ),
+                context.pushNamed(
+                  PlanTeamplateView.routeName,
+                  pathParameters: {'templateName': templateNames[index]},
                 );
               },
               child: Padding(

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:planit/theme/planit_colors.dart';
@@ -14,6 +15,7 @@ import 'package:planit/ui/common/comopnent/planit_toast.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/const/planit_chips_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/component/custom_chip.dart';
 import 'package:planit/ui/plan/component/plan_wrap_grid.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_state.dart';
@@ -21,6 +23,7 @@ import 'package:planit/ui/plan/plan_create/plan_create_view_model.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class PlanCreateView extends HookConsumerWidget {
+  static String get routeName => 'plan_create';
   final int? planId;
   final String? planStatus;
   const PlanCreateView({super.key, this.planId, this.planStatus});
@@ -287,11 +290,7 @@ class PlanCreateView extends HookConsumerWidget {
                                   label: '플랜이 제작됐어요!',
                                 ),
                               );
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => PlanView()), //임시
-                              );
+                              context.goNamed(RootTab.routeName);
                             } else {
                               await viewmodel.updatePlanCreateInfo(planId!);
                               toast.showToast(
@@ -299,11 +298,7 @@ class PlanCreateView extends HookConsumerWidget {
                                   label: '플랜이 수정됐어요!',
                                 ),
                               );
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => PlanView()), //임시
-                              );
+                              context.goNamed(RootTab.routeName);
                             }
                           } catch (e) {
                             toast.showToast(

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
@@ -28,13 +29,10 @@ class PlanMoreBottomSheet extends HookConsumerWidget {
               padding: const EdgeInsets.only(top: 12),
               child: GestureDetector(
                 onTap: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => PlanCreateView(
-                                planId: planId,
-                                planStatus: planStatus,
-                              )));
+                  context.pushNamed(
+                    PlanCreateView.routeName,
+                    queryParameters: {'planId': planId.toString()},
+                  );
                 },
                 child: PlanitText('플랜 수정', style: PlanitTypos.body2),
               ),

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
@@ -16,6 +17,7 @@ import 'package:planit/ui/plan/plan_main/plan_state.dart';
 import 'package:planit/ui/plan/plan_main/plan_view_model.dart';
 
 class PlanView extends HookConsumerWidget {
+  static String get routeName => 'plan';
   const PlanView({super.key});
 
   @override
@@ -126,13 +128,9 @@ class PlanView extends HookConsumerWidget {
                         width: double.infinity,
                         child: PlanitButton(
                             onPressed: () {
-                              Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) => PlanViewAll(
-                                            planList: state.activePlans,
-                                            isActive: true,
-                                          )));
+                              context.pushNamed(PlanViewAll.routeName,
+                                  pathParameters: {'isActive': 'true'},
+                                  extra: state.activePlans);
                             },
                             buttonColor: PlanitButtonColor.white,
                             buttonSize: PlanitButtonSize.large,
@@ -176,13 +174,9 @@ class PlanView extends HookConsumerWidget {
                         width: double.infinity,
                         child: PlanitButton(
                             onPressed: () {
-                              Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) => PlanViewAll(
-                                            planList: state.pausePlans,
-                                            isActive: false,
-                                          )));
+                              context.pushNamed(PlanViewAll.routeName,
+                                  pathParameters: {'isActive': 'false'},
+                                  extra: state.pausePlans);
                             },
                             buttonColor: PlanitButtonColor.white,
                             buttonSize: PlanitButtonSize.large,
@@ -214,6 +208,7 @@ class PlanView extends HookConsumerWidget {
 }
 
 class PlanViewAll extends StatefulWidget {
+  static String get routeName => 'plan_all';
   final List<PlanModel> planList;
   final bool isActive;
 
@@ -267,11 +262,8 @@ class _PlanViewAllState extends State<PlanViewAll> {
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: PlanitButton(
                     onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const PlanCreateView(),
-                        ),
+                      context.pushNamed(
+                        PlanCreateView.routeName,
                       );
                     },
                     buttonColor: PlanitButtonColor.black,
@@ -370,12 +362,7 @@ class BuildAppBar extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 20),
           child: PlanitButton(
             onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => PlanCreateView(),
-                ),
-              );
+              context.pushNamed(PlanCreateView.routeName);
             },
             buttonColor: PlanitButtonColor.black,
             buttonSize: PlanitButtonSize.small,

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -252,26 +252,7 @@ class _PlanViewAllState extends State<PlanViewAll> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          AppBar(
-            toolbarHeight: 92,
-            backgroundColor: PlanitColors.white02,
-            automaticallyImplyLeading: false,
-            title: PlanitText('내 플랜', style: PlanitTypos.title2),
-            actions: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitButton(
-                    onPressed: () {
-                      context.pushNamed(
-                        PlanCreateView.routeName,
-                      );
-                    },
-                    buttonColor: PlanitButtonColor.black,
-                    buttonSize: PlanitButtonSize.small,
-                    label: '+ 새 플랜'),
-              ),
-            ],
-          ),
+          BuildAppBar(),
           if (widget.isActive)
             Padding(
               padding: const EdgeInsets.only(top: 20),

--- a/lib/ui/plan/plan_template/plan_teamplate_view.dart
+++ b/lib/ui/plan/plan_template/plan_teamplate_view.dart
@@ -7,6 +7,7 @@ import 'package:planit/ui/plan/component/template_detail_card.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 
 class PlanTeamplateView extends StatelessWidget {
+  static String get routeName => 'plan_template';
   final String templateName;
   const PlanTeamplateView({required this.templateName, super.key});
 

--- a/lib/ui/plan/plan_template/plan_template_detail_view.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/repository/plan/plan_repository.dart';
 import 'package:planit/repository/task/model/task_model.dart';
@@ -9,6 +10,7 @@ import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/comopnent/planit_toast.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/component/task_card.dart';
 import 'package:planit/ui/plan/component/template_detail_card.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
@@ -16,6 +18,7 @@ import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view_model.dart';
 
 class PlanTemplateDetailView extends HookConsumerWidget {
+  static String get routeName => 'template_detail';
   final PlanTemplateDetail templateDetai;
   const PlanTemplateDetailView({required this.templateDetai, super.key});
 
@@ -76,10 +79,7 @@ class PlanTemplateDetailView extends HookConsumerWidget {
                     try {
                       await viewmodel.createPlanAndAddTask(templateDetai);
                       if (context.mounted) {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(builder: (context) => PlanView()),
-                        );
+                        context.pushNamed(RootTab.routeName);
                       }
                     } catch (e) {
                       // 에러 처리 로직 추가


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- plan 관련 페이지 고라우터 설정을 해봤습니다
- 플랜메인화면으로 가면 하단바가 없어져길래 플랜 메인화면으로 가는 부분들 다 RootTab으로 이동하게 했습니다

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 플랜 관련 다양한 화면(목록, 상세, 생성, 템플릿, 템플릿 상세)으로 이동할 수 있는 새로운 라우트가 추가되었습니다.

* **Refactor**
  * 기존 Navigator 기반의 이동 방식을 go_router 패키지의 명명된 라우트 방식으로 전환하여, 화면 이동이 더 일관되고 직관적으로 개선되었습니다.
  * 각 플랜 관련 주요 화면에 routeName 정적 getter가 추가되어 라우트 관리가 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->