### PR TITLE
Pl 164/feat/chang/archivinig gorouter setting

### DIFF
--- a/lib/data_source/archiving/archiving_data_source.dart
+++ b/lib/data_source/archiving/archiving_data_source.dart
@@ -25,7 +25,7 @@ abstract class ArchivingDataSource {
   @Headers({'accessToken': 'true'})
   Future<ApiResponse<ArchivingPlanResponseBody>> getArchivingPlanLists();
 
-  @PATCH('/planit/plans/{planId}/restart')
+  @PATCH('/planit/archives/{planId}/restart')
   @Headers({'accessToken': 'true'})
   Future<ApiResponse<ArchivingRestartPlanResponseBody>> restartPlan({
     @Path('planId') required int planId,

--- a/lib/data_source/archiving/archiving_data_source.g.dart
+++ b/lib/data_source/archiving/archiving_data_source.g.dart
@@ -63,7 +63,7 @@ class _ArchivingDataSource implements ArchivingDataSource {
       Options(method: 'PATCH', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/planit/plans/${planId}/restart',
+            '/planit/archives/${planId}/restart',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -3,6 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/routes/redirect_notifier.dart';
+import 'package:planit/ui/archiving/archiving_complete/archiving_complete_naviagtor.dart';
+import 'package:planit/ui/archiving/archiving_complete/archiving_complete_view.dart';
+import 'package:planit/ui/archiving/archiving_detail/archiving_detail_view.dart';
+import 'package:planit/ui/archiving/archiving_main/archiving_view.dart';
+import 'package:planit/ui/archiving/archiving_restart/archiving_restart_view.dart';
 import 'package:planit/ui/common/const/web_view_params.dart';
 import 'package:planit/ui/common/view/planit_web_view.dart';
 import 'package:planit/ui/common/view/root_tab.dart';
@@ -165,7 +170,67 @@ class AppRouter {
                         child: PlanTemplateDetailView(
                             templateDetai: templateDetail));
                   }),
+              GoRoute(
+                path: 'archiving',
+                name: ArchivingView.routeName,
+                pageBuilder: (context, state) => NoTransitionPage(
+                  child: ArchivingView(),
+                ),
+                routes: [
+                  GoRoute(
+                      path: 'archivingDetail/:planId',
+                      name: ArchivingDetailView.routeName,
+                      pageBuilder: (context, state) {
+                        final planIdStr = state.pathParameters['planId']!;
+                        final planId = int.parse(planIdStr);
+                        return NoTransitionPage(
+                          child: ArchivingDetailView(
+                            planId: planId,
+                          ),
+                        );
+                      }),
+                  GoRoute(
+                    path: 'archivingRestart/:planId/:title',
+                    name: ArchivingRestartView.routeName,
+                    pageBuilder: (context, state) {
+                      final planIdStr = state.pathParameters['planId']!;
+                      final planId = int.parse(planIdStr);
+                      final title = state.pathParameters['title']!;
+
+                      return NoTransitionPage(
+                        child: ArchivingRestartView(
+                          planId: planId,
+                          title: title,
+                        ),
+                      );
+                    },
+                  ),
+                  GoRoute(
+                    path: 'archivingComplete/:icon/:title',
+                    name: ArchivingCompleteView.routeName,
+                    pageBuilder: (context, state) {
+                      final icon = state.pathParameters['icon']!;
+                      final title = state.pathParameters['title']!;
+                      return NoTransitionPage(
+                          child:
+                              ArchivingCompleteView(icon: icon, title: title));
+                    },
+                  ),
+                  GoRoute(
+                    path: 'archivingCompleteNavigator/:icon/:title',
+                    name: ArchivingCompleteNavigator.routeName,
+                    pageBuilder: (context, state) {
+                      final icon = state.pathParameters['icon']!;
+                      final title = state.pathParameters['title']!;
+                      return NoTransitionPage(
+                          child: ArchivingCompleteNavigator(
+                              icon: icon, title: title));
+                    },
+                  )
+                ],
+              ),
             ],
+            //아카이빙
           ),
           // 길티프리
           GoRoute(

--- a/lib/ui/archiving/archiving_complete/archiving_complete_naviagtor.dart
+++ b/lib/ui/archiving/archiving_complete/archiving_complete_naviagtor.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:planit/repository/archiving/model/archiving_plan_model.dart';
@@ -15,6 +16,7 @@ import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class ArchivingCompleteNavigator extends StatelessWidget {
+  static String get routeName => 'archiving-complete-navigator';
   final String icon;
   final String title;
   const ArchivingCompleteNavigator(
@@ -71,10 +73,7 @@ class ArchivingCompleteNavigator extends StatelessWidget {
                   width: double.infinity,
                   child: PlanitButton(
                     onPressed: () {
-                      Navigator.push(context,
-                          MaterialPageRoute(builder: (context) {
-                        return RootTab();
-                      }));
+                      context.pushNamed(RootTab.routeName);
                     },
                     buttonColor: PlanitButtonColor.black,
                     buttonSize: PlanitButtonSize.large,
@@ -85,10 +84,7 @@ class ArchivingCompleteNavigator extends StatelessWidget {
                   width: double.infinity,
                   child: PlanitButton(
                     onPressed: () {
-                      Navigator.push(context,
-                          MaterialPageRoute(builder: (context) {
-                        return RootTab();
-                      }));
+                      context.pushNamed(RootTab.routeName);
                     },
                     buttonColor: PlanitButtonColor.white,
                     buttonSize: PlanitButtonSize.large,

--- a/lib/ui/archiving/archiving_complete/archiving_complete_view.dart
+++ b/lib/ui/archiving/archiving_complete/archiving_complete_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/repository/archiving/model/archiving_plan_model.dart';
 import 'package:planit/repository/plan/model/plan_detail_model.dart';
@@ -15,6 +16,7 @@ import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class ArchivingCompleteView extends StatelessWidget {
+  static String get routeName => 'archiving-complete';
   final String icon;
   final String title;
   const ArchivingCompleteView(
@@ -62,9 +64,10 @@ class ArchivingCompleteView extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 36),
               child: GestureDetector(
                 onTap: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return ArchivingCompleteNavigator(icon: icon, title: title);
-                  }));
+                  context.pushNamed(
+                    ArchivingCompleteNavigator.routeName,
+                    pathParameters: {'title': title, 'icon': icon},
+                  );
                 },
                 child: Container(
                     decoration: BoxDecoration(color: PlanitColors.white02),

--- a/lib/ui/archiving/archiving_detail/archiving_detail_view.dart
+++ b/lib/ui/archiving/archiving_detail/archiving_detail_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
@@ -18,6 +19,7 @@ import 'package:planit/ui/plan/plan_detail/plan_detail_view_model.dart';
 
 class ArchivingDetailView extends HookConsumerWidget {
   final int planId;
+  static String get routeName => 'archiving-detail';
   const ArchivingDetailView({super.key, required this.planId});
 
   @override
@@ -140,12 +142,13 @@ class ArchivingDetailView extends HookConsumerWidget {
             width: double.infinity,
             child: PlanitButton(
                 onPressed: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return ArchivingRestartView(
-                      planId: planId,
-                      title: state.planDetail?.title ?? '',
-                    );
-                  }));
+                  context.pushNamed(
+                    ArchivingRestartView.routeName,
+                    pathParameters: {
+                      'planId': planId.toString(),
+                      'title': state.planDetail!.title
+                    },
+                  );
                 },
                 buttonColor: PlanitButtonColor.black,
                 buttonSize: PlanitButtonSize.large,

--- a/lib/ui/archiving/archiving_main/archiving_view.dart
+++ b/lib/ui/archiving/archiving_main/archiving_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/repository/archiving/model/archiving_plan_model.dart';
 import 'package:planit/theme/planit_colors.dart';
@@ -12,6 +13,7 @@ import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 
 class ArchivingView extends HookConsumerWidget {
+  static String get routeName => 'archiving';
   const ArchivingView({super.key});
 
   @override
@@ -174,11 +176,12 @@ class _ArchivePlanScrollState extends State<ArchivePlanScroll> {
                 aspectRatio: aspectRatio,
                 child: GestureDetector(
                     onTap: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => ArchivingDetailView(
-                                  planId: widget.plans[index].planId)));
+                      context.pushNamed(
+                        ArchivingDetailView.routeName,
+                        pathParameters: {
+                          'planId': widget.plans[index].planId.toString()
+                        },
+                      );
                     },
                     child: ArchivePlanCard(plan: widget.plans[index])),
               ),

--- a/lib/ui/archiving/archiving_restart/archiving_restart_view.dart
+++ b/lib/ui/archiving/archiving_restart/archiving_restart_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/repository/archiving/model/archiving_plan_model.dart';
@@ -11,10 +12,12 @@ import 'package:planit/ui/common/comopnent/planit_button.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
+import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class ArchivingRestartView extends HookConsumerWidget {
   final int planId;
+  static String get routeName => 'archiving-restart';
   final String title;
   const ArchivingRestartView(
       {super.key, required this.planId, required this.title});
@@ -72,12 +75,7 @@ class ArchivingRestartView extends HookConsumerWidget {
                     final state = ref.read(archivingRestartViewModelProvider);
                     if (state.loadingStatus == LoadingStatus.success &&
                         context.mounted) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => PlanView(),
-                        ),
-                      );
+                      context.pushNamed(RootTab.routeName);
                     } else if (state.loadingStatus == LoadingStatus.error &&
                         context.mounted) {
                       // 에러 처리 (예: 스낵바 표시)

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -67,11 +67,9 @@ class PlanMoreBottomSheet extends HookConsumerWidget {
                   final state = ref.read(planMoreBottomSheetViewModelProvider);
                   if (state.loadingStatus == LoadingStatus.success &&
                       context.mounted) {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => PlanView(),
-                      ),
+                    context.pushNamed(
+                      ArchivingCompleteView.routeName,
+                      pathParameters: {'title': title, 'icon': icon},
                     );
                   } else if (state.loadingStatus == LoadingStatus.error &&
                       context.mounted) {


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 아키이빙 관련 화면에 대한 고라우터 구성을 했습니다
- restartPlan API주소 수정도 햇습니다

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 아카이빙 관련 화면(메인, 상세, 재시작, 완료, 완료 내비게이터) 및 라우팅이 추가되었습니다.
  * 각 아카이빙 화면에 대해 고유한 라우트 이름이 도입되어 명명된 라우팅이 지원됩니다.

* **Refactor**
  * 기존 Navigator 기반 화면 이동이 go_router 기반 명명 라우팅으로 일괄 변경되었습니다.
  * 플랜 재시작 API 경로가 "plans"에서 "archives"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->