### PR TITLE
[Feat] 플랜 레이아웃

### DIFF
--- a/lib/data_source/plan/plan_data_source.dart
+++ b/lib/data_source/plan/plan_data_source.dart
@@ -6,11 +6,8 @@ import 'package:planit/data_source/plan/reponse_body/plan_create_response_body.d
 import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/data_source/plan/reponse_body/plan_response_body.dart';
 import 'package:planit/data_source/plan/request_%20body/plan_request_body.dart';
-import 'package:planit/repository/plan/model/plan_detail_model.dart';
-import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/service/network/dio_service.dart';
 import 'package:retrofit/retrofit.dart';
-import '../../core/api_response.dart';
 
 part 'plan_data_source.g.dart';
 

--- a/lib/data_source/task/request_body/task_request_body.dart
+++ b/lib/data_source/task/request_body/task_request_body.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'task_request_body.g.dart';
+
+@JsonSerializable()
+class TaskRequestBody {
+  final String title;
+  final String taskType;
+
+  TaskRequestBody({
+    required this.title,
+    required this.taskType,
+  });
+
+  Map<String, dynamic> toJson() => _$TaskRequestBodyToJson(this);
+}

--- a/lib/data_source/task/request_body/task_request_body.g.dart
+++ b/lib/data_source/task/request_body/task_request_body.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'task_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TaskRequestBody _$TaskRequestBodyFromJson(Map<String, dynamic> json) =>
+    TaskRequestBody(
+      title: json['title'] as String,
+      taskType: json['taskType'] as String,
+    );
+
+Map<String, dynamic> _$TaskRequestBodyToJson(TaskRequestBody instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'taskType': instance.taskType,
+    };

--- a/lib/data_source/task/task_data_source.dart
+++ b/lib/data_source/task/task_data_source.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart' hide Headers;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:planit/data_source/main/reponse_body/today_tasks_response_body.dart';
 import 'package:planit/data_source/task/request_body/routine_request_body.dart';
+import 'package:planit/data_source/task/request_body/task_request_body.dart';
 import 'package:planit/data_source/task/response_body/routine_response_body.dart';
 import 'package:planit/data_source/task/response_body/task_create_response_body.dart';
 import 'package:planit/service/network/dio_service.dart';
@@ -22,10 +22,10 @@ abstract class TaskDataSource {
 
   @POST('/planit/tasks')
   @Headers({'accessToken': 'true'})
-  Future<ApiResponse<TaskCreateResponseBody>> createTask(
-    @Query('planId') int planId,
-    @Query('title') String title,
-  );
+  Future<ApiResponse<TaskCreateResponseBody>> createTask({
+    @Query('planId') required int planId,
+    @Body() required TaskRequestBody body,
+  });
 
   @PATCH('/planit/tasks/{taskId}/routine')
   @Headers({'accessToken': 'true'})

--- a/lib/data_source/task/task_data_source.g.dart
+++ b/lib/data_source/task/task_data_source.g.dart
@@ -6,7 +6,7 @@ part of 'task_data_source.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
 
 class _TaskDataSource implements TaskDataSource {
   _TaskDataSource(this._dio, {this.baseUrl, this.errorLogger});
@@ -18,18 +18,15 @@ class _TaskDataSource implements TaskDataSource {
   final ParseErrorLogger? errorLogger;
 
   @override
-  Future<ApiResponse<TaskCreateResponseBody>> createTask(
-    int planId,
-    String title,
-  ) async {
+  Future<ApiResponse<TaskCreateResponseBody>> createTask({
+    required int planId,
+    required TaskRequestBody body,
+  }) async {
     final _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{
-      r'planId': planId,
-      r'title': title,
-    };
+    final queryParameters = <String, dynamic>{r'planId': planId};
     final _headers = <String, dynamic>{r'accessToken': 'true'};
     _headers.removeWhere((k, v) => v == null);
-    const Map<String, dynamic>? _data = null;
+    final _data = body;
     final _options = _setStreamType<ApiResponse<TaskCreateResponseBody>>(
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(

--- a/lib/repository/plan/model/plan_detail_model.dart
+++ b/lib/repository/plan/model/plan_detail_model.dart
@@ -2,7 +2,6 @@
 import 'package:planit/data_source/plan/reponse_body/plan_detail_response_body.dart';
 import 'package:planit/data_source/task/response_body/task_create_response_body.dart';
 import 'package:planit/repository/task/model/task_model.dart';
-import 'package:planit/ui/main/component/task_widget.dart';
 
 class PlanDetailModel {
   final int planId;

--- a/lib/repository/plan/plan_repository.dart
+++ b/lib/repository/plan/plan_repository.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/rendering.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/api_response.dart';
 import 'package:planit/core/error_message.dart';
@@ -14,9 +13,6 @@ import 'package:planit/repository/archiving/model/archiving_complete_model.dart'
 import 'package:planit/repository/plan/model/plan_create_model.dart';
 import 'package:planit/repository/plan/model/plan_detail_model.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
-import 'package:planit/repository/task/model/task_model.dart';
-import 'package:planit/ui/common/assets.dart';
-import 'package:planit/ui/plan/plan_template/plan_template.dart';
 
 final AutoDisposeProvider<PlanRepository> planRepositoryProvider =
     Provider.autoDispose<PlanRepository>(

--- a/lib/repository/task/task_repository.dart
+++ b/lib/repository/task/task_repository.dart
@@ -4,6 +4,7 @@ import 'package:planit/core/api_response.dart';
 import 'package:planit/core/error_message.dart';
 import 'package:planit/core/repository_result.dart';
 import 'package:planit/data_source/task/request_body/routine_request_body.dart';
+import 'package:planit/data_source/task/request_body/task_request_body.dart';
 import 'package:planit/data_source/task/response_body/routine_response_body.dart';
 import 'package:planit/data_source/task/response_body/task_create_response_body.dart';
 import 'package:planit/data_source/task/task_data_source.dart';
@@ -64,11 +65,20 @@ class TaskRepository {
     }
   }
 
-  Future<RepositoryResult<TaskModel>> addTask(
-      {required String title, required int planId}) async {
+  Future<RepositoryResult<TaskModel>> addTask({
+    required String title,
+    required int planId,
+    required String taskType,
+  }) async {
     try {
       final ApiResponse<TaskCreateResponseBody> result =
-          await _taskDataSource.createTask(planId, title);
+          await _taskDataSource.createTask(
+        planId: planId,
+        body: TaskRequestBody(
+          title: title,
+          taskType: taskType,
+        ),
+      );
       final model = TaskModel.fromResponse(result.data);
       return SuccessRepositoryResult(data: model);
     } on DioException catch (e) {

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -19,6 +19,7 @@ import 'package:planit/ui/mypage/view/mypage_view.dart';
 import 'package:planit/ui/onboarding/onboarding_view.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
 import 'package:planit/ui/plan/plan_detail/plan_detail_view.dart';
+import 'package:planit/ui/plan/plan_main/plan_all_view.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_teamplate_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
@@ -107,13 +108,13 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: 'all/:isActive',
-                name: PlanViewAll.routeName,
+                name: PlanAllView.routeName,
                 pageBuilder: (context, state) {
                   final planList = state.extra as List<PlanModel>? ?? [];
                   final isActiveStr = state.pathParameters['isActive']!;
                   final isActive = bool.parse(isActiveStr);
                   return NoTransitionPage(
-                      child: PlanViewAll(
+                      child: PlanAllView(
                     planList: planList,
                     isActive: isActive,
                   ));

--- a/lib/ui/common/comopnent/planit_bottom_sheet.dart
+++ b/lib/ui/common/comopnent/planit_bottom_sheet.dart
@@ -34,6 +34,10 @@ class PlanitBottomSheet extends StatelessWidget {
     return Container(
       width: double.infinity,
       height: height,
+      // 키보드 올라올 때 바텀시트가 키보드 위로 올라갈 수 있도록
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       decoration: BoxDecoration(
         color: PlanitColors.white01,
         borderRadius: BorderRadius.only(

--- a/lib/ui/common/comopnent/planit_button.dart
+++ b/lib/ui/common/comopnent/planit_button.dart
@@ -54,7 +54,7 @@ class PlanitButton extends StatelessWidget {
             ? PlanitColors.black01
             : PlanitColors.black01.withValues(alpha: 0.5))
         : ((buttonColor == PlanitButtonColor.white)
-            ? PlanitColors.white01
+            ? PlanitColors.white03
             : PlanitColors.red);
 
     final Color overlayColor = (buttonColor == PlanitButtonColor.black)

--- a/lib/ui/plan/component/condition_tip_table_row.dart
+++ b/lib/ui/plan/component/condition_tip_table_row.dart
@@ -15,35 +15,58 @@ class ConditionTipTableRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 32),
-      child: Table(
-        columnWidths: {
-          0: const FlexColumnWidth(4),
-          1: const FixedColumnWidth(40),
-          2: const FlexColumnWidth(4),
-        },
-        children: [
-          TableRow(children: [
-            PlanitText(
-              left,
-              style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
-            ),
-            const Padding(
-              padding: EdgeInsets.only(right: double.infinity),
-              child: PlanitText('→',
-                  style: TextStyle(
-                    fontSize: 18,
-                    color: PlanitColors.black03,
-                  )),
-            ),
-            PlanitText(
-              right,
-              style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
-            ),
-          ]),
-        ],
-      ),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          flex: 3,
+          child: PlanitText(
+            left,
+            style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: PlanitText(
+            '→',
+            style: PlanitTypos.body3.copyWith(color: PlanitColors.white03),
+          ),
+        ),
+        Expanded(
+          flex: 4,
+          child: PlanitText(
+            right,
+            style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
+          ),
+        ),
+      ],
     );
+    // return Table(
+    //   columnWidths: {
+    //     0: const FlexColumnWidth(4),
+    //     1: const FixedColumnWidth(40),
+    //     2: const FlexColumnWidth(4),
+    //   },
+    //   children: [
+    //     TableRow(children: [
+    //       PlanitText(
+    //         left,
+    //         style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
+    //       ),
+    //       const Padding(
+    //         padding: EdgeInsets.only(right: double.infinity),
+    //         child: PlanitText('→',
+    //             style: TextStyle(
+    //               fontSize: 18,
+    //               color: PlanitColors.black03,
+    //             )),
+    //       ),
+    //       PlanitText(
+    //         right,
+    //         style: PlanitTypos.body3.copyWith(color: PlanitColors.black03),
+    //       ),
+    //     ]),
+    //   ],
+    // );
   }
 }

--- a/lib/ui/plan/component/plan_list_card.dart
+++ b/lib/ui/plan/component/plan_list_card.dart
@@ -3,13 +3,9 @@ import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
-import 'package:planit/ui/common/comopnent/planit_chip.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
-import 'package:planit/ui/common/const/planit_chips_style.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
-import 'package:planit/ui/plan/component/custom_chip.dart';
 import 'package:planit/ui/plan/component/plan_main_chip.dart';
-import 'package:planit/ui/plan/plan_detail/plan_detail_view.dart';
 
 class PlanListCard extends StatelessWidget {
   final PlanModel plan;

--- a/lib/ui/plan/component/plan_wrap_grid.dart
+++ b/lib/ui/plan/component/plan_wrap_grid.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:planit/theme/planit_colors.dart';
-import 'package:planit/ui/common/assets.dart';
 
 class PlanetWrapGrid extends StatelessWidget {
   final String? selectedIcon;

--- a/lib/ui/plan/component/task_card.dart
+++ b/lib/ui/plan/component/task_card.dart
@@ -12,11 +12,12 @@ class TaskCard extends StatelessWidget {
   final String taskType;
   final int taskId;
 
-  const TaskCard(
-      {super.key,
-      required this.title,
-      required this.taskId,
-      required this.taskType});
+  const TaskCard({
+    super.key,
+    required this.title,
+    required this.taskId,
+    required this.taskType,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -59,18 +60,19 @@ class TaskCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4),
                 child: GestureDetector(
-                    onTap: () {
-                      showModalBottomSheet(
-                        context: context,
-                        isScrollControlled: false,
-                        builder: (context) {
-                          return TaskMoreBottomSheetView(
-                            taskId: taskId,
-                          );
-                        },
-                      );
-                    },
-                    child: SvgPicture.asset(Assets.more)),
+                  onTap: () {
+                    showModalBottomSheet(
+                      context: context,
+                      isScrollControlled: false,
+                      builder: (context) {
+                        return TaskMoreBottomSheetView(
+                          taskId: taskId,
+                        );
+                      },
+                    );
+                  },
+                  child: SvgPicture.asset(Assets.more),
+                ),
               ),
             ],
           ),

--- a/lib/ui/plan/component/template_detail_card.dart
+++ b/lib/ui/plan/component/template_detail_card.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
-import 'package:planit/repository/task/model/task_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/assets.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
-import 'package:planit/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart';
-import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view.dart';
 

--- a/lib/ui/plan/component/template_list.dart
+++ b/lib/ui/plan/component/template_list.dart
@@ -25,29 +25,33 @@ class TemplateList extends StatelessWidget {
       '관계',
     ];
 
-    return Padding(
-      padding: const EdgeInsets.only(left: 20),
-      child: SizedBox(
-        height: 100,
-        child: ListView.builder(
-          shrinkWrap: true,
-          scrollDirection: Axis.horizontal,
-          itemCount: templateImage.length,
-          itemBuilder: (context, index) {
-            return GestureDetector(
-              onTap: () {
-                context.pushNamed(
-                  PlanTeamplateView.routeName,
-                  pathParameters: {'templateName': templateNames[index]},
-                );
-              },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: SvgPicture.asset(templateImage[index]),
+    return SizedBox(
+      height: 112,
+      child: ListView.separated(
+        shrinkWrap: true,
+        scrollDirection: Axis.horizontal,
+        itemCount: templateImage.length,
+        padding: EdgeInsets.zero,
+        separatorBuilder: (context, index) => SizedBox(width: 12),
+        itemBuilder: (context, index) {
+          return GestureDetector(
+            onTap: () {
+              context.pushNamed(
+                PlanTeamplateView.routeName,
+                pathParameters: {'templateName': templateNames[index]},
+              );
+            },
+            child: Padding(
+              // 첫번째 아이템에만 좌측 패딩
+              padding: EdgeInsets.only(left: index == 0 ? 20 : 0),
+              child: SvgPicture.asset(
+                templateImage[index],
+                height: 112,
+                width: 144,
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/plan/plan_create/plan_create_state.dart
+++ b/lib/ui/plan/plan_create/plan_create_state.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:planit/core/loading_status.dart';
-import 'package:planit/ui/plan/component/plan_list_card.dart';
 
 part 'plan_create_state.freezed.dart';
 

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -25,21 +25,28 @@ class PlanCreateView extends HookConsumerWidget {
   static String get routeName => 'plan_create';
   final int? planId;
   final String? planStatus;
+
   const PlanCreateView({super.key, this.planId, this.planStatus});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    PlanCreateState state = ref.watch(planViewModelProvider);
-    PlanCreateViewModel viewmodel = ref.read(planViewModelProvider.notifier);
+    final PlanCreateState state = ref.watch(planViewModelProvider);
+    final PlanCreateViewModel viewmodel = ref.read(
+      planViewModelProvider.notifier,
+    );
+
     final toast = FToast().init(context);
+
     final titleController = useTextEditingController();
     final motivationController = useTextEditingController();
+
     useEffect(() {
       if (planId != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           viewmodel.init(planId!);
         });
       }
+
       if (planStatus != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           viewmodel.updatePlanStatus(planStatus!);
@@ -47,6 +54,7 @@ class PlanCreateView extends HookConsumerWidget {
       }
       return null;
     }, [planId, planStatus]);
+
     useEffect(() {
       titleController.text = state.title;
       motivationController.text = state.motivation;
@@ -54,135 +62,151 @@ class PlanCreateView extends HookConsumerWidget {
     }, [state.title, state.motivation]);
 
     return DefaultLayout(
-        child: SingleChildScrollView(
-      child: Column(
-        children: [
-          AppBar(
-              backgroundColor: PlanitColors.transparent,
-              title: PlanitText('내 플랜 만들기',
-                  style:
-                      PlanitTypos.body2.copyWith(color: PlanitColors.black01))),
-          Column(
+      title: '내 플랜 만들기',
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 20),
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             spacing: 20.0,
             children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20)
-                    .copyWith(top: 28),
-                child: Row(
-                  children: [
-                    PlanitText(
-                      '플랜 제목',
-                      style: PlanitTypos.body2
-                          .copyWith(color: PlanitColors.black02),
-                    ),
-                    PlanitText(
-                      '*',
-                      style:
-                          PlanitTypos.body2.copyWith(color: PlanitColors.alert),
-                    ),
-                    PlanitText(
-                      '(20자 내)',
-                      style: PlanitTypos.body3
-                          .copyWith(color: PlanitColors.black03),
-                    ),
-                  ],
-                ),
-              ),
-              ShakeWidget(
-                shake: state.isClickedNext == true && state.title == '',
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: PlanitTextField(
-                    maxLength: 20,
-                    hintText: state.isClickedNext == true && state.title == ''
-                        ? null
-                        : '당신의 목표는 무엇인가요?',
-                    errorText: state.isClickedNext == true && state.title == ''
-                        ? '당신의 목표는 무엇인가요?'
-                        : null,
-                    controller: titleController,
-                    onChanged: viewmodel.updateTitle,
+              // 플랜 제목
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12,
+                children: [
+                  Row(
+                    children: [
+                      PlanitText(
+                        '플랜 제목',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.black02,
+                        ),
+                      ),
+                      PlanitText(
+                        '*',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.alert,
+                        ),
+                      ),
+                      PlanitText(
+                        ' (20자 내)',
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    PlanitText('다짐 문장',
-                        style: PlanitTypos.body2
-                            .copyWith(color: PlanitColors.black02)),
-                    PlanitText(' (40 내)',
-                        style: PlanitTypos.body3
-                            .copyWith(color: PlanitColors.black03)),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitTextField(
-                  hintText: '이 플랜을 지속할 수 있는 요소가 있나요?',
-                  controller: motivationController,
-                  onChanged: viewmodel.updateMotivation,
-                  maxLength: 40,
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Row(
-                  children: [
-                    PlanitText('행성 아이콘 선택',
-                        style: TextStyle(
-                            fontWeight: FontWeight.w500,
-                            fontSize: 16,
-                            color: PlanitColors.black02)),
-                    PlanitText(
-                      '*',
-                      style:
-                          PlanitTypos.body2.copyWith(color: PlanitColors.alert),
+                  ShakeWidget(
+                    shake: state.isClickedNext == true && state.title == '',
+                    child: PlanitTextField(
+                      maxLength: 20,
+                      hintText: state.isClickedNext == true && state.title == ''
+                          ? null
+                          : '당신의 목표는 무엇인가요?',
+                      errorText:
+                          state.isClickedNext == true && state.title == ''
+                              ? '당신의 목표는 무엇인가요?'
+                              : null,
+                      controller: titleController,
+                      onChanged: viewmodel.updateTitle,
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-              ShakeWidget(
-                shake: state.isClickedNext && state.icon.isEmpty,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20)
-                      .copyWith(top: 12),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: Border.all(
+              // 다짐 문장
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      PlanitText(
+                        '다짐 문장',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.black02,
+                        ),
+                      ),
+                      PlanitText(
+                        ' (40자 내)',
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                    ],
+                  ),
+                  PlanitTextField(
+                    hintText: '이 플랜을 지속할 수 있는 요소가 있나요?',
+                    controller: motivationController,
+                    onChanged: viewmodel.updateMotivation,
+                    maxLength: 40,
+                  ),
+                ],
+              ),
+              // 행성 아이콘 선택
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12,
+                children: [
+                  Row(
+                    children: [
+                      PlanitText(
+                        '행성 아이콘 선택',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w500,
+                          fontSize: 16,
+                          color: PlanitColors.black02,
+                        ),
+                      ),
+                      PlanitText(
+                        '*',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.alert,
+                        ),
+                      ),
+                    ],
+                  ),
+                  ShakeWidget(
+                    shake: state.isClickedNext && state.icon.isEmpty,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        border: Border.all(
                           color: (state.isClickedNext && state.icon.isEmpty)
                               ? PlanitColors.alert
-                              : PlanitColors.transparent),
-                    ),
-                    child: PlanetWrapGrid(
+                              : PlanitColors.transparent,
+                        ),
+                      ),
+                      child: PlanetWrapGrid(
                         selectedIcon: state.icon,
                         onSelect: (asset) {
                           viewmodel.updateIcon(asset);
-                        }),
+                        },
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20)
-                    .copyWith(top: 12),
-                child: PlanitText('목표일 설정',
-                    style: PlanitTypos.body2
-                        .copyWith(color: PlanitColors.black02)),
-              ),
-              Row(
+              // 목표일 설정
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    child: GestureDetector(
+                  PlanitText(
+                    '목표일 설정',
+                    style: PlanitTypos.body2.copyWith(
+                      color: PlanitColors.black02,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      GestureDetector(
                         onTap: () async {
                           final DateTime? selectedDate = await showDatePicker(
-                              context: context,
-                              firstDate: DateTime.now(),
-                              lastDate: DateTime(2100));
+                            context: context,
+                            firstDate: DateTime.now(),
+                            lastDate: DateTime(2100),
+                          );
 
                           if (selectedDate != null) {
                             final formatDate =
@@ -196,45 +220,55 @@ class PlanCreateView extends HookConsumerWidget {
                           title: state.selectedDate!,
                           textcolor: PlanitColors.black03,
                           backgroundcolor: PlanitColors.white01,
-                        )),
-                  ),
-                  PlanitText('까지 | D-${state.dDay}',
-                      style: TextStyle(
+                        ),
+                      ),
+                      SizedBox(width: 8),
+                      PlanitText(
+                        '까지 | D-${state.dDay}',
+                        style: TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w400,
-                          color: PlanitColors.black03)),
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                    ],
+                  ),
                 ],
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20)
-                    .copyWith(top: 12),
-                child: Row(
-                  children: [
-                    PlanitText('플랜 진행 여부',
-                        style: PlanitTypos.body2
-                            .copyWith(color: PlanitColors.black02)),
-                    PlanitText(
-                      '*',
-                      style:
-                          PlanitTypos.body2.copyWith(color: PlanitColors.alert),
-                    ),
-                  ],
-                ),
-              ),
-              ShakeWidget(
-                shake: state.isClickedNext && state.planStatus.isEmpty,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: Row(
-                    spacing: 8,
+              // 플랜 진행 여부
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 12,
+                children: [
+                  Row(
                     children: [
-                      GestureDetector(
+                      PlanitText(
+                        '플랜 진행 여부',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.black02,
+                        ),
+                      ),
+                      PlanitText(
+                        '*',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.alert,
+                        ),
+                      ),
+                    ],
+                  ),
+                  ShakeWidget(
+                    shake: state.isClickedNext && state.planStatus.isEmpty,
+                    child: Row(
+                      spacing: 8,
+                      children: [
+                        GestureDetector(
                           onTap: () =>
                               viewmodel.updatePlanStatus('IN_PROGRESS'),
                           child: Container(
                             decoration: BoxDecoration(
-                              borderRadius:
-                                  BorderRadius.all(Radius.circular(37)),
+                              borderRadius: BorderRadius.all(
+                                Radius.circular(37),
+                              ),
                               border: Border.all(
                                 color: (state.isClickedNext &&
                                         state.planStatus.isEmpty)
@@ -243,12 +277,14 @@ class PlanCreateView extends HookConsumerWidget {
                               ),
                             ),
                             child: PlanitChip(
-                                chipColor: state.planStatus == 'IN_PROGRESS'
-                                    ? PlanitChipColor.black
-                                    : PlanitChipColor.gray,
-                                label: '진행 중'),
-                          )),
-                      GestureDetector(
+                              chipColor: state.planStatus == 'IN_PROGRESS'
+                                  ? PlanitChipColor.black
+                                  : PlanitChipColor.gray,
+                              label: '진행 중',
+                            ),
+                          ),
+                        ),
+                        GestureDetector(
                           onTap: () => viewmodel.updatePlanStatus('PAUSED'),
                           child: Container(
                             decoration: BoxDecoration(
@@ -262,64 +298,72 @@ class PlanCreateView extends HookConsumerWidget {
                               ),
                             ),
                             child: PlanitChip(
-                                chipColor: state.planStatus == 'PAUSED'
-                                    ? PlanitChipColor.black
-                                    : PlanitChipColor.gray,
-                                label: '중단'),
-                          )),
-                    ],
+                              chipColor: state.planStatus == 'PAUSED'
+                                  ? PlanitChipColor.black
+                                  : PlanitChipColor.gray,
+                              label: '중단',
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
+                ],
               ),
+              // 버튼
               Padding(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 20).copyWith(bottom: 40),
+                padding: const EdgeInsets.only(top: 16),
                 child: SizedBox(
                   width: double.infinity,
                   child: PlanitButton(
-                      onPressed: () async {
-                        viewmodel.updateClickedNext();
+                    onPressed: () async {
+                      viewmodel.updateClickedNext();
 
-                        if (state.isNextEnabled) {
-                          try {
-                            if (planId == null) {
-                              await viewmodel.uploadPlan();
-                              toast.showToast(
-                                child: PlanitToast(
-                                  label: '플랜이 제작됐어요!',
-                                ),
-                              );
-                              context.goNamed(RootTab.routeName);
-                            } else {
-                              await viewmodel.updatePlanCreateInfo(planId!);
-                              toast.showToast(
-                                child: PlanitToast(
-                                  label: '플랜이 수정됐어요!',
-                                ),
-                              );
-                              context.goNamed(RootTab.routeName);
-                            }
-                          } catch (e) {
+                      if (state.isNextEnabled) {
+                        try {
+                          if (planId == null) {
+                            await viewmodel.uploadPlan();
                             toast.showToast(
                               child: PlanitToast(
-                                label: planId == null
-                                    ? '플랜 생성에 실패했습니다.'
-                                    : '플랜 수정에 실패했습니다.',
+                                label: '플랜이 제작됐어요!',
                               ),
                             );
+                            if (context.mounted) {
+                              context.goNamed(RootTab.routeName);
+                            }
+                          } else {
+                            await viewmodel.updatePlanCreateInfo(planId!);
+                            toast.showToast(
+                              child: PlanitToast(
+                                label: '플랜이 수정됐어요!',
+                              ),
+                            );
+                            if (context.mounted) {
+                              context.goNamed(RootTab.routeName);
+                            }
                           }
+                        } catch (e) {
+                          toast.showToast(
+                            child: PlanitToast(
+                              label: planId == null
+                                  ? '플랜 생성에 실패했습니다.'
+                                  : '플랜 수정에 실패했습니다.',
+                            ),
+                          );
                         }
-                      },
-                      buttonColor: PlanitButtonColor.black,
-                      buttonSize: PlanitButtonSize.large,
-                      label: '플랜 만들기'),
+                      }
+                    },
+                    buttonColor: PlanitButtonColor.black,
+                    buttonSize: PlanitButtonSize.large,
+                    label: '플랜 만들기',
+                  ),
                 ),
               ),
             ],
           ),
-        ],
+        ),
       ),
-    ));
+    );
   }
 }
 

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -206,11 +206,37 @@ class PlanCreateView extends HookConsumerWidget {
                             context: context,
                             firstDate: DateTime.now(),
                             lastDate: DateTime(2100),
+                            builder: (context, child) => Theme(
+                              data: Theme.of(context).copyWith(
+                                colorScheme: ColorScheme.light(
+                                  primary: PlanitColors.white03,
+                                  surface: PlanitColors.white01,
+                                  onPrimary: PlanitColors.red,
+                                  onSurface: PlanitColors.black01,
+                                ),
+                                textTheme: TextTheme(
+                                  bodyLarge: TextStyle(
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.w400,
+                                    fontFamily: 'Pretendard',
+                                    color: PlanitColors.black01,
+                                  ),
+                                ),
+                                textButtonTheme: TextButtonThemeData(
+                                  style: TextButton.styleFrom(
+                                    foregroundColor: PlanitColors.black01,
+                                    textStyle: PlanitTypos.body2,
+                                  ),
+                                ),
+                              ),
+                              child: child!,
+                            ),
                           );
 
                           if (selectedDate != null) {
-                            final formatDate =
-                                DateFormat('yy-MM-dd').format(selectedDate);
+                            final formatDate = DateFormat('yy-MM-dd').format(
+                              selectedDate,
+                            );
                             viewmodel.updateSelectedDate(formatDate);
                             viewmodel.calculateDday(selectedDate);
                           }

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -20,7 +20,6 @@ import 'package:planit/ui/plan/component/custom_chip.dart';
 import 'package:planit/ui/plan/component/plan_wrap_grid.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_state.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view_model.dart';
-import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class PlanCreateView extends HookConsumerWidget {
   static String get routeName => 'plan_create';

--- a/lib/ui/plan/plan_create/plan_create_view_model.dart
+++ b/lib/ui/plan/plan_create/plan_create_view_model.dart
@@ -2,10 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/core/repository_result.dart';
-import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/repository/plan/plan_repository.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_state.dart';
-import 'package:planit/ui/plan/plan_main/plan_state.dart';
 
 //StateNotifierProvider 생성자에 타입 명시하는 걸 추가하여 타입 안정성 향상
 final StateNotifierProvider<PlanCreateViewModel, PlanCreateState>

--- a/lib/ui/plan/plan_detail/bottom_sheet/conditional_tip_bottom_sheet.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/conditional_tip_bottom_sheet.dart
@@ -14,121 +14,91 @@ class ConditionTipBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //Wrap으로 감싸면 자식 높이만큼 알아서 height 맞춰줌!
-    return Wrap(children: [
-      PlanitBottomSheet(
-        content: Column(
-          spacing: 8.0,
+    return PlanitBottomSheet(
+      content: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 32),
-              child: Row(
+            PlanitText(
+              '컨디션을 정하는 팁?',
+              style: PlanitTypos.title2.copyWith(
+                color: PlanitColors.black01,
+              ),
+            ),
+            SizedBox(height: 32),
+            PlanitChip(
+              chipColor: PlanitChipColor.gray,
+              label: '🔥 힘이 넘칠 때',
+            ),
+            SizedBox(height: 12),
+            PlanitText(
+              '플랜의 핵심 목표 달성을 위한 기본 루틴이에요.',
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.black02,
+              ),
+            ),
+            SizedBox(height: 20),
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+                color: PlanitColors.white02,
+              ),
+              padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+              width: double.infinity,
+              child: Column(
+                spacing: 10,
                 children: [
-                  PlanitText('컨디션을 정하는 팁?', style: PlanitTypos.title2),
+                  ConditionTipTableRow(left: '자기소개서 플랜', right: '도입부 1차 완성'),
+                  ConditionTipTableRow(left: '운동 플랜', right: '근력운동 30분'),
+                  ConditionTipTableRow(left: '취업 플랜', right: '포트폴리오 항목 1개 정리'),
                 ],
               ),
             ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 32),
-              child: Row(
+            SizedBox(height: 32),
+            PlanitChip(
+              chipColor: PlanitChipColor.gray,
+              label: '💧 지쳤을 때',
+            ),
+            SizedBox(height: 12),
+            PlanitText(
+              '본격적으로 플랜을 진행할 때 첫 시작이 버겁죠.\n시작의 문을 여는 일을 적으면 좋아요',
+              style: PlanitTypos.body2.copyWith(
+                color: PlanitColors.black02,
+              ),
+            ),
+            SizedBox(height: 20),
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+                color: PlanitColors.white02,
+              ),
+              padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+              width: double.infinity,
+              child: Column(
+                spacing: 10,
                 children: [
-                  PlanitChip(
-                    chipColor: PlanitChipColor.gray,
-                    label: '🔥 힘이 넘칠 때',
-                  ),
+                  ConditionTipTableRow(left: '자기소개서 플랜', right: '항목 별 키워드만 정리'),
+                  ConditionTipTableRow(left: '운동 플랜', right: '스트레칭 5분'),
+                  ConditionTipTableRow(left: '취업 플랜', right: '지원 기업 리스트 적기'),
                 ],
               ),
             ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 12),
-              child: Row(
-                children: [
-                  PlanitText('플랜의 핵심 목표 달성을 위한 기본 루틴이에요.',
-                      style: PlanitTypos.body2
-                          .copyWith(color: PlanitColors.black02))
-                ],
+            SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: PlanitButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                buttonColor: PlanitButtonColor.black,
+                buttonSize: PlanitButtonSize.large,
+                label: '닫기',
               ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16).copyWith(top: 16),
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.all(Radius.circular(8)),
-                  color: PlanitColors.white02,
-                ),
-                width: double.infinity,
-                child: Column(
-                  children: [
-                    ConditionTipTableRow(left: '자기소개서 플랜', right: '도입부 1차 완성'),
-                    ConditionTipTableRow(left: '운동 플랜', right: '근력운동 30분'),
-                    ConditionTipTableRow(
-                        left: '취업 플랜', right: '포트폴리오 항목 1개 정리'),
-                  ],
-                ),
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 32),
-              child: Row(
-                children: [
-                  PlanitChip(
-                    chipColor: PlanitChipColor.gray,
-                    label: '💧 지쳤을 때',
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 4),
-              child: Row(
-                children: [
-                  PlanitText('본격적으로 플랜을 진행할 때 첫 시작이 버겁죠.\n시작의 문을 여는 일을 적으면 좋아요',
-                      style: PlanitTypos.body2
-                          .copyWith(color: PlanitColors.black02))
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16).copyWith(top: 16),
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.all(Radius.circular(8)),
-                  color: PlanitColors.white02,
-                ),
-                width: double.infinity,
-                child: Column(
-                  children: [
-                    ConditionTipTableRow(
-                        left: '자기소개서 플랜', right: '항목 별 키워드만 정리'),
-                    ConditionTipTableRow(left: '운동 플랜', right: '스트레칭 5분'),
-                    ConditionTipTableRow(left: '취업 플랜', right: '지원 기업 리스트 적기'),
-                  ],
-                ),
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12).copyWith(top: 12),
-              child: SizedBox(
-                  width: double.infinity,
-                  child: PlanitButton(
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      buttonColor: PlanitButtonColor.black,
-                      buttonSize: PlanitButtonSize.large,
-                      label: '닫기')),
             ),
           ],
         ),
       ),
-    ]);
+    );
   }
 }

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_state.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_state.dart
@@ -1,8 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:planit/core/loading_status.dart';
-import 'package:planit/repository/plan/model/plan_detail_model.dart';
-import 'package:planit/repository/task/model/task_model.dart';
-import 'package:planit/repository/plan/model/plan_model.dart';
 
 part 'plan_more_bottom_sheet_state.freezed.dart';
 

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -4,12 +4,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
-import 'package:planit/ui/archiving/archiving_complete/archiving_complete_view.dart';
 import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
 import 'package:planit/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view_model.dart';
-import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart';
 import 'package:planit/ui/plan/plan_main/plan_view.dart';
 
 class PlanMoreBottomSheet extends HookConsumerWidget {

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
+import 'package:planit/ui/common/comopnent/planit_button.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/comopnent/planit_text_field.dart';
+import 'package:planit/ui/common/const/planit_button_style.dart';
 
 class TaskAddBottomSheetView extends StatefulWidget {
   final void Function(String title) onConfirm;
@@ -16,57 +19,68 @@ class TaskAddBottomSheetView extends StatefulWidget {
 
 class _TaskAddBottomSheetViewState extends State<TaskAddBottomSheetView> {
   late final TextEditingController controller;
+
+  // 텍스트필드 내 입력값 즉시 감지하기 위함
+  bool isTextNotEmpty = false;
+
   @override
   void initState() {
     super.initState();
-    controller = TextEditingController();
+    controller = TextEditingController()
+      ..addListener(() {
+        final newValue = controller.text.isNotEmpty;
+        if (isTextNotEmpty != newValue) {
+          setState(() {
+            isTextNotEmpty = newValue;
+          });
+        }
+      });
   }
 
   @override
   void dispose() {
-    controller.dispose(); 
+    controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(children: [
-      PlanitBottomSheet(
-        content: Column(
-          spacing: 8.0,
+    return PlanitBottomSheet(
+      content: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20).copyWith(
+          top: 16,
+        ),
+        child: Column(
           children: [
-            PlanitText('할 일을 생성해주세요', style: PlanitTypos.title3),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-              child: PlanitTextField(
-                hintText: '내용을 입력해주세요',
-                controller: controller,
+            PlanitText(
+              '할 일을 작성해주세요',
+              style: PlanitTypos.title3.copyWith(
+                color: PlanitColors.black01,
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: GestureDetector(
-                onTap: () {
+            SizedBox(height: 16),
+            PlanitTextField(
+              hintText: '내용을 입력해주세요',
+              controller: controller,
+            ),
+            SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: PlanitButton(
+                onPressed: () {
                   final title = controller.text.trim();
                   widget.onConfirm(title);
-                  Navigator.of(context).pop();
+                  context.pop();
                 },
-                child: PlanitText('생성', style: PlanitTypos.body2),
+                buttonColor: PlanitButtonColor.black,
+                buttonSize: PlanitButtonSize.large,
+                label: '생성하기',
+                enabled: isTextNotEmpty,
               ),
             ),
-            Divider(
-              color: PlanitColors.white03,
-            ),
-            GestureDetector(
-              onTap: () {
-                Navigator.pop(context);
-              },
-              child: PlanitText('취소',
-                  style: PlanitTypos.body2.copyWith(color: PlanitColors.alert)),
-            )
           ],
         ),
       ),
-    ]);
+    );
   }
 }

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_state.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_state.dart
@@ -1,8 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:planit/core/loading_status.dart';
-import 'package:planit/repository/plan/model/plan_detail_model.dart';
-import 'package:planit/repository/task/model/task_model.dart';
-import 'package:planit/repository/plan/model/plan_model.dart';
 
 part 'task_edit_bottom_sheet_state.freezed.dart';
 

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
@@ -16,14 +16,18 @@ import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bott
 
 class TaskEditBottomSheetView extends HookConsumerWidget {
   final int taskId;
+
   const TaskEditBottomSheetView({super.key, required this.taskId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final TaskEditBottomSheetState state =
-        ref.watch(taskEditViewModelProvider(taskId));
-    final TaskEditBottomSheetViewModel viewmodel =
-        ref.read(taskEditViewModelProvider(taskId).notifier);
+    final TaskEditBottomSheetState state = ref.watch(
+      taskEditViewModelProvider(taskId),
+    );
+    final TaskEditBottomSheetViewModel viewmodel = ref.read(
+      taskEditViewModelProvider(taskId).notifier,
+    );
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         viewmodel.init();
@@ -31,170 +35,159 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
       return null;
     }, []);
 
-    return Wrap(children: [
-      PlanitBottomSheet(
-        content: Column(
-          children: [
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 32),
-              child: Row(
-                children: [
-                  PlanitText('루틴 설정', style: PlanitTypos.title2),
-                ],
-              ),
+    return Wrap(
+      children: [
+        PlanitBottomSheet(
+          content: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20).copyWith(
+              top: 24,
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 32),
-              child: Row(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    child: PlanitText('반복 요일',
-                        style: PlanitTypos.body3
-                            .copyWith(color: PlanitColors.black03)),
-                  )
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: Row(
-                spacing: 4,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: List.generate(7, (index) {
-                  const days = ['월', '화', '수', '목', '금', '토', '일'];
-                  return GestureDetector(
-                    onTap: () {
-                      viewmodel.toggleDay(days[index]);
-                    },
-                    child: CircleAvatar(
-                      radius: 25,
-                      backgroundColor: state.routinDayList.contains(days[index])
-                          ? PlanitColors.black01
-                          : PlanitColors.white02,
-                      child: PlanitText(days[index],
-                          style: PlanitTypos.body3.copyWith(
-                            color: state.routinDayList.contains(days[index])
-                                ? PlanitColors.white01
-                                : PlanitColors.black02,
-                          )),
-                    ),
-                  );
-                }),
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 12),
-              child: Row(
-                children: [
-                  PlanitText(
-                    '시간 설정',
-                    style:
-                        PlanitTypos.body3.copyWith(color: PlanitColors.black03),
+            child: Column(
+              children: [
+                PlanitText(
+                  '루틴 설정',
+                  style: PlanitTypos.title2.copyWith(
+                    color: PlanitColors.black01,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: PlanitToggle(
-                        onChanged: (value) {
-                          viewmodel.toggleTimeSetting();
-                        },
-                        isOn: state.timeSetting),
-                  )
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 4),
-              child: Row(
-                children: [
-                  Container(
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.all(Radius.circular(4)),
-                        color: PlanitColors.white02),
-                    width: 56,
-                    height: 40,
-                    child: Center(
-                      child: PlanitText('8:00',
-                          style: TextStyle(
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 20),
+                  child: Row(
+                    children: [
+                      PlanitText(
+                        '반복 요일',
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: List.generate(
+                      7,
+                      (index) {
+                        const days = ['월', '화', '수', '목', '금', '토', '일'];
+                        return GestureDetector(
+                          onTap: () => viewmodel.toggleDay(days[index]),
+                          child: CircleAvatar(
+                            radius: 25,
+                            backgroundColor:
+                                state.routinDayList.contains(days[index])
+                                    ? PlanitColors.black01
+                                    : PlanitColors.white02,
+                            child: PlanitText(
+                              days[index],
+                              style: PlanitTypos.body3.copyWith(
+                                color: state.routinDayList.contains(days[index])
+                                    ? PlanitColors.white01
+                                    : PlanitColors.black02,
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Row(
+                    children: [
+                      PlanitText(
+                        '시간 설정',
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: PlanitToggle(
+                          onChanged: (value) {
+                            viewmodel.toggleTimeSetting();
+                          },
+                          isOn: state.timeSetting,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Row(
+                    children: [
+                      Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.all(Radius.circular(4)),
+                          color: PlanitColors.white02,
+                        ),
+                        width: 56,
+                        height: 40,
+                        child: Center(
+                          child: PlanitText(
+                            '8:00',
+                            style: TextStyle(
                               //피그마에 size14, weight400라 적혀있어서 TextStyle썼습니다
                               fontSize: 14,
                               fontWeight: FontWeight.w400,
-                              color: PlanitColors.black04)),
-                    ),
-                  )
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 20),
-              child: Row(
-                children: [
-                  PlanitText('이 할일은 어떤 컨디션일때 하기 좋아요?',
-                      style: PlanitTypos.body3
-                          .copyWith(color: PlanitColors.black03))
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16).copyWith(top: 16),
-              child: Row(
-                spacing: 10,
-                children: [
-                  GestureDetector(
-                    onTap: () {
-                      viewmodel.toggleType('HIGH');
-                    },
-                    child: PlanitChip(
-                      chipColor: state.taskType.contains('HIGH')
-                          ? PlanitChipColor.black
-                          : PlanitChipColor.gray,
-                      label: '🔥 힘이 넘칠 때',
-                    ),
+                              color: PlanitColors.black04,
+                            ),
+                          ),
+                        ),
+                      )
+                    ],
                   ),
-                  GestureDetector(
-                    onTap: () {
-                      viewmodel.toggleType('LOW');
-                    },
-                    child: PlanitChip(
-                      chipColor: state.taskType.contains('LOW')
-                          ? PlanitChipColor.black
-                          : PlanitChipColor.gray,
-                      label: '💧 지쳤을 때',
-                    ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 20),
+                  child: Row(
+                    children: [
+                      PlanitText(
+                        '이 할일은 어떤 컨디션일때 하기 좋아요?',
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      )
+                    ],
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 20),
-              child: Row(
-                spacing: 4,
-                children: [
-                  Container(
-                    width: 20,
-                    height: 20,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: PlanitColors.transparent,
-                      border: Border.all(
-                        color: PlanitColors.black03,
-                        width: 1.5,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Row(
+                    spacing: 12,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          viewmodel.toggleType('HIGH');
+                        },
+                        child: PlanitChip(
+                          chipColor: state.taskType.contains('HIGH')
+                              ? PlanitChipColor.black
+                              : PlanitChipColor.gray,
+                          label: '🔥 힘이 넘칠 때',
+                        ),
                       ),
-                    ),
-                    child: Center(
-                      child: PlanitText('?',
-                          style: TextStyle(
-                              color: PlanitColors.black03,
-                              fontWeight: FontWeight.w600)),
-                    ),
+                      GestureDetector(
+                        onTap: () {
+                          viewmodel.toggleType('LOW');
+                        },
+                        child: PlanitChip(
+                          chipColor: state.taskType.contains('LOW')
+                              ? PlanitChipColor.black
+                              : PlanitChipColor.gray,
+                          label: '💧 지쳤을 때',
+                        ),
+                      ),
+                    ],
                   ),
-                  GestureDetector(
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  // 물음표까지 터치영역 확장
+                  child: GestureDetector(
                     onTap: () {
                       showModalBottomSheet(
                         isScrollControlled: true,
@@ -202,32 +195,60 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                         builder: (context) => ConditionTipBottomSheet(),
                       );
                     },
-                    child: PlanitText('컨디션을 정하는 팁',
-                        style: PlanitTypos.caption
-                            .copyWith(color: PlanitColors.black03)),
+                    child: Row(
+                      spacing: 4,
+                      children: [
+                        Container(
+                          width: 20,
+                          height: 20,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: PlanitColors.transparent,
+                            border: Border.all(
+                              color: PlanitColors.black03,
+                              width: 1.5,
+                            ),
+                          ),
+                          child: Center(
+                            child: PlanitText(
+                              '?',
+                              style: TextStyle(
+                                color: PlanitColors.black03,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ),
+                        PlanitText(
+                          '컨디션을 정하는 팁',
+                          style: PlanitTypos.caption.copyWith(
+                            color: PlanitColors.black03,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 88),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                child: SizedBox(
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 40),
+                  child: SizedBox(
                     width: double.infinity,
                     child: PlanitButton(
-                        onPressed: () {
-                          viewmodel.saveEditedRoutine();
-                          Navigator.pop(context);
-                        },
-                        buttonColor: PlanitButtonColor.black,
-                        buttonSize: PlanitButtonSize.large,
-                        label: '저장')),
-              ),
+                      onPressed: () {
+                        viewmodel.saveEditedRoutine();
+                        Navigator.pop(context);
+                      },
+                      buttonColor: PlanitButtonColor.black,
+                      buttonSize: PlanitButtonSize.large,
+                      label: '저장',
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
-      ),
-    ]);
+      ],
+    );
   }
 }

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
@@ -1,7 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/core/repository_result.dart';
-import 'package:planit/repository/plan/plan_repository.dart';
 import 'package:planit/repository/task/model/routine_model.dart';
 import 'package:planit/repository/task/task_repository.dart';
 import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_state.dart';

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view.dart
@@ -9,6 +9,7 @@ import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bott
 
 class TaskMoreBottomSheetView extends HookConsumerWidget {
   final int taskId;
+
   const TaskMoreBottomSheetView({
     super.key,
     required this.taskId,
@@ -18,14 +19,12 @@ class TaskMoreBottomSheetView extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final TaskMoreBottomSheetViewModel viewmodel =
         ref.read(taskMoreBottomSheetViewModelProvider(taskId).notifier);
-    return Wrap(children: [
-      PlanitBottomSheet(
-        content: Column(
-          spacing: 8.0,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: GestureDetector(
+    return Wrap(
+      children: [
+        PlanitBottomSheet(
+          content: Column(
+            children: [
+              GestureDetector(
                 onTap: () {
                   Navigator.pop(context);
                   showModalBottomSheet(
@@ -36,22 +35,40 @@ class TaskMoreBottomSheetView extends HookConsumerWidget {
                     ),
                   );
                 },
-                child: PlanitText('수정', style: PlanitTypos.body2),
+                // 터치 영역 확장 위해 흰색 컨테이너 사용
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  color: PlanitColors.white01,
+                  child: PlanitText(
+                    '할 일 상세 설정',
+                    style: PlanitTypos.body2.copyWith(
+                      color: PlanitColors.black01,
+                    ),
+                  ),
+                ),
               ),
-            ),
-            Divider(
-              color: PlanitColors.white03,
-            ),
-            GestureDetector(
-              onTap: () {
-                viewmodel.clickDeleteTask();
-              },
-              child: PlanitText('삭제',
-                  style: PlanitTypos.body2.copyWith(color: PlanitColors.alert)),
-            )
-          ],
+              Divider(
+                color: PlanitColors.white03,
+              ),
+              GestureDetector(
+                onTap: () {
+                  viewmodel.clickDeleteTask();
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  color: PlanitColors.white01,
+                  child: PlanitText(
+                    '삭제',
+                    style: PlanitTypos.body2.copyWith(
+                      color: PlanitColors.alert,
+                    ),
+                  ),
+                ),
+              )
+            ],
+          ),
         ),
-      ),
-    ]);
+      ],
+    );
   }
 }

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view_model.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view_model.dart
@@ -1,9 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/core/repository_result.dart';
-import 'package:planit/repository/plan/plan_repository.dart';
 import 'package:planit/repository/task/task_repository.dart';
-import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_state.dart';
 import 'package:planit/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_state.dart';
 
 final taskMoreBottomSheetViewModelProvider = StateNotifierProvider.family<

--- a/lib/ui/plan/plan_detail/plan_detail_state.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_state.dart
@@ -1,8 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/repository/plan/model/plan_detail_model.dart';
-import 'package:planit/repository/task/model/task_model.dart';
-import 'package:planit/repository/plan/model/plan_model.dart';
 
 part 'plan_detail_state.freezed.dart';
 

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -141,22 +141,20 @@ class PlanDetailView extends HookConsumerWidget {
                       ),
                     ),
                     // 태스크 리스트
-                    SizedBox(
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        itemCount: state.planDetail!.tasks.length,
-                        itemBuilder: (context, index) {
-                          final item = state.planDetail!.tasks[index];
-                          return Padding(
-                            padding: const EdgeInsets.only(bottom: 12),
-                            child: TaskCard(
-                              title: item.title,
-                              taskType: item.taskType,
-                              taskId: item.taskId,
-                            ),
-                          );
-                        },
-                      ),
+                    ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: state.planDetail!.tasks.length,
+                      itemBuilder: (context, index) {
+                        final item = state.planDetail!.tasks[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: TaskCard(
+                            title: item.title,
+                            taskType: item.taskType,
+                            taskId: item.taskId,
+                          ),
+                        );
+                      },
                     ),
                   ],
                 ),

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -54,6 +54,7 @@ class PlanDetailView extends HookConsumerWidget {
               icon: Icon(Icons.add, color: PlanitColors.white01),
               onPressed: () {
                 showModalBottomSheet(
+                  isScrollControlled: true,
                   context: context,
                   builder: (context) {
                     return TaskAddBottomSheetView(

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -4,7 +4,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/assets.dart';
+import 'package:planit/ui/common/comopnent/planit_loading.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:planit/ui/plan/component/task_card.dart';
@@ -16,15 +18,18 @@ import 'package:planit/ui/plan/plan_detail/plan_detail_view_model.dart';
 class PlanDetailView extends HookConsumerWidget {
   final int planId;
   final String planStatus;
+
   const PlanDetailView(
       {required this.planId, required this.planStatus, super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final PlanDetailState state =
-        ref.watch(planDetailViewModelProvider(planId));
-    final PlanDetailViewModel viewModel =
-        ref.read(planDetailViewModelProvider(planId).notifier);
+    final PlanDetailState state = ref.watch(
+      planDetailViewModelProvider(planId),
+    );
+    final PlanDetailViewModel viewModel = ref.read(
+      planDetailViewModelProvider(planId).notifier,
+    );
 
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -33,123 +38,131 @@ class PlanDetailView extends HookConsumerWidget {
       return null;
     }, []);
 
-    if (state.loadingStatus == LoadingStatus.loading) {
-      return Center(child: CircularProgressIndicator());
-    }
-    if (state.planDetail == null) {
-      return Center(child: CircularProgressIndicator());
-    }
-
     return DefaultLayout(
-        floatingActionButton: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-          child: GestureDetector(
-            child: Container(
-              width: 48,
-              height: 48,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: PlanitColors.black01, // 배경색
-              ),
-              child: IconButton(
-                icon: Icon(Icons.add, color: PlanitColors.white01),
-                onPressed: () {
-                  showModalBottomSheet(
-                      context: context,
-                      builder: (context) {
-                        return TaskAddBottomSheetView(
-                          onConfirm: (title) {
-                            viewModel.clickAddButton(title);
-                          },
-                        );
-                      });
+      title: '',
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+        child: GestureDetector(
+          child: Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: PlanitColors.black01, // 배경색
+            ),
+            child: IconButton(
+              icon: Icon(Icons.add, color: PlanitColors.white01),
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  builder: (context) {
+                    return TaskAddBottomSheetView(
+                      onConfirm: (title) {
+                        viewModel.clickAddButton(title);
+                      },
+                    );
+                  },
+                );
 
-                  // 버튼 눌렀을 때 동작
-                },
-              ),
+                // 버튼 눌렀을 때 동작
+              },
             ),
           ),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            AppBar(
-              backgroundColor: PlanitColors.transparent,
-            ),
-            SizedBox(
-              width: double.infinity,
-              height: 136,
-              child: Stack(
-                children: [
-                  Align(
-                    alignment: Alignment.center,
-                    child: SvgPicture.asset(
-                      '${state.planDetail!.icon}.svg',
-                      width: 120,
-                      height: 120,
-                    ),
-                  ),
-                  Positioned(
-                    top: 8,
-                    right: 20,
-                    child: GestureDetector(
-                      onTap: () {
-                        showModalBottomSheet(
-                          context: context,
-                          builder: (context) {
-                            return PlanMoreBottomSheet(
-                              title: state.planDetail!.title,
-                              planStatus: planStatus,
-                              planId: planId,
-                              icon: state.planDetail!.icon,
-                            );
-                          },
-                        );
-                      },
-                      child: SvgPicture.asset(
-                        Assets.more,
-                        width: 24,
-                        height: 24,
+      ),
+      child: state.planDetail == null
+          ? Center(child: PlanitLoading())
+          : Stack(
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    // 플랜 아이콘 및 설정 버튼
+                    SizedBox(
+                      width: double.infinity,
+                      height: 136,
+                      child: Stack(
+                        children: [
+                          Align(
+                            alignment: Alignment.center,
+                            child: SvgPicture.asset(
+                              '${state.planDetail!.icon}.svg',
+                              width: 120,
+                              height: 120,
+                            ),
+                          ),
+                          Positioned(
+                            top: 8,
+                            right: 20,
+                            child: GestureDetector(
+                              onTap: () {
+                                showModalBottomSheet(
+                                  context: context,
+                                  builder: (context) {
+                                    return PlanMoreBottomSheet(
+                                      title: state.planDetail!.title,
+                                      planStatus: planStatus,
+                                      planId: planId,
+                                      icon: state.planDetail!.icon,
+                                    );
+                                  },
+                                );
+                              },
+                              child: SvgPicture.asset(
+                                Assets.more,
+                                width: 24,
+                                height: 24,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 12.0),
-              child: PlanitText(state.planDetail!.title,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w700,
-                  )),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 12.0, bottom: 40),
-              child: PlanitText(state.planDetail!.motivation,
-                  style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
-                      color: PlanitColors.black03)),
-            ),
-            SizedBox(
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: state.planDetail!.tasks.length,
-                itemBuilder: (context, index) {
-                  final item = state.planDetail!.tasks[index];
-                  return Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: TaskCard(
-                      title: item.title,
-                      taskType: item.taskType,
-                      taskId: item.taskId,
+                    // 플랜명
+                    Padding(
+                      padding: const EdgeInsets.only(top: 12.0),
+                      child: PlanitText(
+                        state.planDetail!.title,
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
                     ),
-                  );
-                },
-              ),
+                    // 동기
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4.0, bottom: 40),
+                      child: PlanitText(
+                        state.planDetail!.motivation,
+                        style: PlanitTypos.body3.copyWith(
+                          color: PlanitColors.black03,
+                        ),
+                      ),
+                    ),
+                    // 태스크 리스트
+                    SizedBox(
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: state.planDetail!.tasks.length,
+                        itemBuilder: (context, index) {
+                          final item = state.planDetail!.tasks[index];
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: TaskCard(
+                              title: item.title,
+                              taskType: item.taskType,
+                              taskId: item.taskId,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                if (state.loadingStatus == LoadingStatus.loading)
+                  Center(child: PlanitLoading())
+              ],
             ),
-          ],
-        ));
+    );
   }
 }

--- a/lib/ui/plan/plan_detail/plan_detail_view_model.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view_model.dart
@@ -52,13 +52,14 @@ class PlanDetailViewModel extends StateNotifier<PlanDetailState> {
     }
   }
 
-
-
   Future<void> clickAddButton(String title) async {
     state = state.copyWith(loadingStatus: LoadingStatus.loading);
 
-    final taskAddResult =
-        await _taskRepository.addTask(title: title, planId: _planId);
+    final taskAddResult = await _taskRepository.addTask(
+      title: title,
+      planId: _planId,
+      taskType: 'ALL',
+    );
 
     if (taskAddResult is SuccessRepositoryResult<TaskModel>) {
       final planDetailResult =

--- a/lib/ui/plan/plan_main/plan_all_view.dart
+++ b/lib/ui/plan/plan_main/plan_all_view.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import '../../../repository/plan/model/plan_model.dart';
+import '../../../theme/planit_colors.dart';
+import '../../common/view/default_layout.dart';
+import '../component/plan_list_card.dart';
+
+class PlanAllView extends StatefulWidget {
+  static String get routeName => 'plan_all';
+  final List<PlanModel> planList;
+  final bool isActive;
+
+  const PlanAllView({
+    super.key,
+    required this.planList,
+    required this.isActive,
+  });
+
+  @override
+  State<PlanAllView> createState() => _PlanAllViewState();
+}
+
+class _PlanAllViewState extends State<PlanAllView> {
+  late final PageController _pageController;
+  int _currentPage = 0;
+  late final List<List<PlanModel>> _pagedPlans;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+    _pagedPlans = _paginate(widget.planList, 6);
+  }
+
+  List<List<PlanModel>> _paginate(List<PlanModel> plans, int size) {
+    List<List<PlanModel>> pages = [];
+    for (int i = 0; i < plans.length; i += size) {
+      pages.add(
+        plans.sublist(i, (i + size > plans.length) ? plans.length : i + size),
+      );
+    }
+    return pages;
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultLayout(
+      title: '플랜 전체보기',
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 20).copyWith(
+          top: 20,
+          bottom: 40,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 태스크 리스트
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _pagedPlans.length,
+                onPageChanged: (index) {
+                  setState(() {
+                    _currentPage = index;
+                  });
+                },
+                itemBuilder: (context, pageIndex) {
+                  final plans = _pagedPlans[pageIndex];
+                  return ListView.separated(
+                    itemCount: plans.length,
+                    separatorBuilder: (context, index) => SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      return PlanListCard(
+                        plan: plans[index],
+                        planStatus: 'PAUSED',
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            // 페이지네이션 UI
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(
+                  _pagedPlans.length,
+                  (index) {
+                    final isActive = index == _currentPage;
+                    return Container(
+                      margin: EdgeInsets.symmetric(horizontal: 4),
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: isActive
+                            ? PlanitColors.black02
+                            : PlanitColors.white03,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/plan/plan_main/plan_state.dart
+++ b/lib/ui/plan/plan_main/plan_state.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:planit/core/loading_status.dart';
-import 'package:planit/ui/plan/component/plan_list_card.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
 
 part 'plan_state.freezed.dart';

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -13,6 +13,7 @@ import 'package:planit/ui/plan/component/plan_list_card.dart';
 import 'package:planit/ui/plan/component/template_list.dart';
 import 'package:planit/repository/plan/model/plan_model.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
+import 'package:planit/ui/plan/plan_main/plan_all_view.dart';
 import 'package:planit/ui/plan/plan_main/plan_state.dart';
 import 'package:planit/ui/plan/plan_main/plan_view_model.dart';
 
@@ -142,6 +143,7 @@ class _PlanList extends StatelessWidget {
           SizedBox(height: 12),
           // 진행 중인 플랜 리스트
           ListView.separated(
+            physics: NeverScrollableScrollPhysics(),
             padding: EdgeInsets.zero,
             shrinkWrap: true,
             itemCount: plans.length > 5 ? 5 : plans.length,
@@ -163,7 +165,7 @@ class _PlanList extends StatelessWidget {
                 child: PlanitButton(
                   onPressed: () {
                     context.pushNamed(
-                      PlanViewAll.routeName,
+                      PlanAllView.routeName,
                       pathParameters: {
                         'isActive':
                             planStatus == 'IN_PROGRESS' ? 'true' : 'false',
@@ -177,138 +179,6 @@ class _PlanList extends StatelessWidget {
                 ),
               ),
             ),
-        ],
-      ),
-    );
-  }
-}
-
-class PlanViewAll extends StatefulWidget {
-  static String get routeName => 'plan_all';
-  final List<PlanModel> planList;
-  final bool isActive;
-
-  const PlanViewAll(
-      {super.key, required this.planList, required this.isActive});
-
-  @override
-  State<PlanViewAll> createState() => _PlanViewAllState();
-}
-
-class _PlanViewAllState extends State<PlanViewAll> {
-  late final PageController _pageController;
-  int _currentPage = 0;
-  late final List<List<PlanModel>> _pagedPlans;
-
-  @override
-  void initState() {
-    super.initState();
-    _pageController = PageController();
-    _pagedPlans = _paginate(widget.planList, 6);
-  }
-
-  List<List<PlanModel>> _paginate(List<PlanModel> plans, int size) {
-    List<List<PlanModel>> pages = [];
-    for (int i = 0; i < plans.length; i += size) {
-      pages.add(
-        plans.sublist(i, (i + size > plans.length) ? plans.length : i + size),
-      );
-    }
-    return pages;
-  }
-
-  @override
-  void dispose() {
-    _pageController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return DefaultLayout(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          BuildAppBar(),
-          if (widget.isActive)
-            Padding(
-              padding: const EdgeInsets.only(top: 20),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText(
-                  '진행 중인 플랜',
-                  style: PlanitTypos.body2.copyWith(
-                    color: PlanitColors.black01,
-                  ),
-                ),
-              ),
-            ),
-          if (!widget.isActive)
-            Padding(
-              padding: const EdgeInsets.only(top: 20),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText(
-                  '잠시 중단한 플랜',
-                  style: PlanitTypos.body2.copyWith(
-                    color: PlanitColors.black01,
-                  ),
-                ),
-              ),
-            ),
-          Expanded(
-            child: PageView.builder(
-              controller: _pageController,
-              itemCount: _pagedPlans.length,
-              onPageChanged: (index) {
-                setState(() {
-                  _currentPage = index;
-                });
-              },
-              itemBuilder: (context, pageIndex) {
-                final plans = _pagedPlans[pageIndex];
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20)
-                      .copyWith(top: 16),
-                  child: ListView.builder(
-                    itemCount: plans.length,
-                    itemBuilder: (context, index) {
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: PlanListCard(
-                          plan: plans[index],
-                          planStatus: 'PAUSED',
-                        ),
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: List.generate(
-                _pagedPlans.length,
-                (index) {
-                  final isActive = index == _currentPage;
-                  return Container(
-                    margin: EdgeInsets.symmetric(horizontal: 4),
-                    width: 8,
-                    height: 8,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: isActive
-                          ? PlanitColors.black02
-                          : PlanitColors.white03,
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -108,6 +108,7 @@ class PlanView extends HookConsumerWidget {
                   ),
                 ],
               ),
+            SizedBox(height: 40),
           ],
         ),
       ),

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -18,192 +18,168 @@ import 'package:planit/ui/plan/plan_main/plan_view_model.dart';
 
 class PlanView extends HookConsumerWidget {
   static String get routeName => 'plan';
+
   const PlanView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final PlanState state = ref.watch(planViewModelProvider);
     final PlanViewModel viewmodel = ref.read(planViewModelProvider.notifier);
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         viewmodel.init();
       });
       return null;
     }, []);
-    if (state.activePlans.isEmpty) {
-      return DefaultLayout(
-          child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          BuildAppBar(),
-          Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
+
+    return DefaultLayout(
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            BuildAppBar(),
+            SizedBox(height: 20),
+            // 진행 중인 플랜
+            if (state.activePlans.isNotEmpty)
+              _PlanList(
+                title: '진행 중인 플랜',
+                plans: state.activePlans,
+                planStatus: 'IN_PROGRESS',
+              ),
+            // 잠시 중단한 플랜
+            if (state.pausePlans.isNotEmpty)
+              Padding(
+                // 진행 중인 플랜이 있을 때만 topPadding=40
+                padding: EdgeInsets.only(
+                  top: state.activePlans.isNotEmpty ? 40 : 0,
+                ),
+                child: _PlanList(
+                  title: '잠시 중단한 플랜',
+                  plans: state.pausePlans,
+                  planStatus: 'PAUSED',
+                ),
+              ),
+            // 템플릿 텍스트
+            Padding(
+              // 진행 중인 플랜/잠시 중단한 플랜 하나라도 있다면 topPadding=32
+              padding: EdgeInsets.only(
+                top: state.activePlans.isNotEmpty || state.pausePlans.isNotEmpty
+                    ? 32
+                    : 0,
+                left: 20,
+                bottom: 12,
+              ),
               child: PlanitText(
                 '템플릿',
-                style: PlanitTypos.body2.copyWith(color: PlanitColors.black01),
+                style: PlanitTypos.body2.copyWith(
+                  color: PlanitColors.black01,
+                ),
               ),
             ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(top: 20),
-            child: TemplateList(),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(top: 20),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: PlanitText('진행 중인 플랜',
-                  style:
-                      PlanitTypos.body2.copyWith(color: PlanitColors.black01)),
-            ),
-          ),
-          Expanded(
-            child: Center(
-              child: Column(
+            TemplateList(),
+            // 플랜이 아예 없는 경우
+            if (state.activePlans.isEmpty && state.pausePlans.isEmpty)
+              Column(
                 mainAxisSize: MainAxisSize.min,
-                spacing: 20,
                 children: [
-                  Text(
-                    '아직 플랜이\n존재하지 않아요!',
-                    style: PlanitTypos.body3.copyWith(
-                      color: PlanitColors.black03,
+                  Align(
+                    alignment: AlignmentDirectional.topStart,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 40, left: 20),
+                      child: PlanitText(
+                        '진행 중인 플랜',
+                        style: PlanitTypos.body2.copyWith(
+                          color: PlanitColors.black01,
+                        ),
+                      ),
                     ),
-                    textAlign: TextAlign.center,
                   ),
-                  Text(
-                    '새로 플랜을 만들어 볼까요?',
-                    style: PlanitTypos.caption.copyWith(
-                      color: PlanitColors.black03,
+                  SizedBox(height: 104),
+                  Center(
+                    child: PlanitText(
+                      '아직 플랜이\n존재하지 않아요!\n\n새로 플랜을 만들어 볼까요?',
+                      textAlign: TextAlign.center,
+                      style: PlanitTypos.body3.copyWith(
+                        color: PlanitColors.black03,
+                      ),
                     ),
-                    textAlign: TextAlign.center,
                   ),
                 ],
               ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanList extends StatelessWidget {
+  final String title;
+  final List<PlanModel> plans;
+  final String planStatus;
+
+  const _PlanList({
+    required this.title,
+    required this.plans,
+    required this.planStatus,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 타이틀
+          PlanitText(
+            title,
+            style: PlanitTypos.body2.copyWith(
+              color: PlanitColors.black01,
             ),
           ),
-        ],
-      ));
-    } else {
-      return DefaultLayout(
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              BuildAppBar(),
-              Padding(
-                padding: const EdgeInsets.only(top: 20),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: PlanitText('진행 중인 플랜',
-                      style: PlanitTypos.body2
-                          .copyWith(color: PlanitColors.black01)),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20)
-                    .copyWith(top: 12),
-                child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: state.activePlans.length > 5
-                        ? 5
-                        : state.activePlans.length,
-                    itemBuilder: (context, index) {
-                      final item = state.activePlans[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 10),
-                        child: PlanListCard(
-                          planStatus: 'IN_PROGRESS',
-                          plan: item,
-                        ),
-                      );
-                    }),
-              ),
-              state.activePlans.length > 5
-                  ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 20)
-                          .copyWith(top: 12),
-                      child: SizedBox(
-                        width: double.infinity,
-                        child: PlanitButton(
-                            onPressed: () {
-                              context.pushNamed(PlanViewAll.routeName,
-                                  pathParameters: {'isActive': 'true'},
-                                  extra: state.activePlans);
-                            },
-                            buttonColor: PlanitButtonColor.white,
-                            buttonSize: PlanitButtonSize.large,
-                            label: '플랜 전체보기'),
-                      ),
-                    )
-                  : SizedBox(),
-              Padding(
-                padding: const EdgeInsets.only(top: 20),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: PlanitText('잠시 중단한 플랜',
-                      style: PlanitTypos.body2
-                          .copyWith(color: PlanitColors.black01)),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20)
-                    .copyWith(top: 12),
-                child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: state.pausePlans.length > 5
-                        ? 5
-                        : state.pausePlans.length,
-                    itemBuilder: (context, index) {
-                      final item = state.pausePlans[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 10),
-                        child: PlanListCard(
-                          planStatus: 'PAUSED',
-                          plan: item,
-                        ),
-                      );
-                    }),
-              ),
-              state.pausePlans.length > 5
-                  ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 20)
-                          .copyWith(top: 12),
-                      child: SizedBox(
-                        width: double.infinity,
-                        child: PlanitButton(
-                            onPressed: () {
-                              context.pushNamed(PlanViewAll.routeName,
-                                  pathParameters: {'isActive': 'false'},
-                                  extra: state.pausePlans);
-                            },
-                            buttonColor: PlanitButtonColor.white,
-                            buttonSize: PlanitButtonSize.large,
-                            label: '플랜 전체보기'),
-                      ),
-                    )
-                  : SizedBox(),
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: PlanitText(
-                    '템플릿',
-                    style:
-                        PlanitTypos.body2.copyWith(color: PlanitColors.black01),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 20),
-                child: TemplateList(),
-              )
-            ],
+          SizedBox(height: 12),
+          // 진행 중인 플랜 리스트
+          ListView.separated(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: plans.length > 5 ? 5 : plans.length,
+            separatorBuilder: (context, index) => SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final item = plans[index];
+              return PlanListCard(
+                planStatus: planStatus,
+                plan: item,
+              );
+            },
           ),
-        ),
-      );
-    }
+          // 진행 중인 플랜 전체보기 버튼
+          if (plans.length > 5)
+            Padding(
+              padding: const EdgeInsets.only(top: 20),
+              child: SizedBox(
+                width: double.infinity,
+                child: PlanitButton(
+                  onPressed: () {
+                    context.pushNamed(
+                      PlanViewAll.routeName,
+                      pathParameters: {
+                        'isActive':
+                            planStatus == 'IN_PROGRESS' ? 'true' : 'false',
+                      },
+                      extra: plans,
+                    );
+                  },
+                  buttonColor: PlanitButtonColor.white,
+                  buttonSize: PlanitButtonSize.large,
+                  label: '플랜 전체보기',
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }
 
@@ -234,8 +210,9 @@ class _PlanViewAllState extends State<PlanViewAll> {
   List<List<PlanModel>> _paginate(List<PlanModel> plans, int size) {
     List<List<PlanModel>> pages = [];
     for (int i = 0; i < plans.length; i += size) {
-      pages.add(plans.sublist(
-          i, (i + size > plans.length) ? plans.length : i + size));
+      pages.add(
+        plans.sublist(i, (i + size > plans.length) ? plans.length : i + size),
+      );
     }
     return pages;
   }
@@ -258,9 +235,12 @@ class _PlanViewAllState extends State<PlanViewAll> {
               padding: const EdgeInsets.only(top: 20),
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText('진행 중인 플랜',
-                    style: PlanitTypos.body2
-                        .copyWith(color: PlanitColors.black01)),
+                child: PlanitText(
+                  '진행 중인 플랜',
+                  style: PlanitTypos.body2.copyWith(
+                    color: PlanitColors.black01,
+                  ),
+                ),
               ),
             ),
           if (!widget.isActive)
@@ -268,9 +248,12 @@ class _PlanViewAllState extends State<PlanViewAll> {
               padding: const EdgeInsets.only(top: 20),
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: PlanitText('잠시 중단한 플랜',
-                    style: PlanitTypos.body2
-                        .copyWith(color: PlanitColors.black01)),
+                child: PlanitText(
+                  '잠시 중단한 플랜',
+                  style: PlanitTypos.body2.copyWith(
+                    color: PlanitColors.black01,
+                  ),
+                ),
               ),
             ),
           Expanded(
@@ -307,19 +290,23 @@ class _PlanViewAllState extends State<PlanViewAll> {
             padding: const EdgeInsets.symmetric(vertical: 16),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: List.generate(_pagedPlans.length, (index) {
-                final isActive = index == _currentPage;
-                return Container(
-                  margin: EdgeInsets.symmetric(horizontal: 4),
-                  width: 8,
-                  height: 8,
-                  decoration: BoxDecoration(
+              children: List.generate(
+                _pagedPlans.length,
+                (index) {
+                  final isActive = index == _currentPage;
+                  return Container(
+                    margin: EdgeInsets.symmetric(horizontal: 4),
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color: isActive
                           ? PlanitColors.black02
-                          : PlanitColors.white03),
-                );
-              }),
+                          : PlanitColors.white03,
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         ],
@@ -337,6 +324,8 @@ class BuildAppBar extends StatelessWidget {
       toolbarHeight: 92,
       backgroundColor: PlanitColors.white02,
       automaticallyImplyLeading: false,
+      scrolledUnderElevation: 0,
+      elevation: 0,
       title: PlanitText('내 플랜', style: PlanitTypos.title2),
       actions: [
         Padding(

--- a/lib/ui/plan/plan_template/plan_teamplate_view.dart
+++ b/lib/ui/plan/plan_template/plan_teamplate_view.dart
@@ -9,6 +9,7 @@ import 'package:planit/ui/plan/plan_template/plan_template.dart';
 class PlanTeamplateView extends StatelessWidget {
   static String get routeName => 'plan_template';
   final String templateName;
+
   const PlanTeamplateView({required this.templateName, super.key});
 
   @override
@@ -36,27 +37,24 @@ class PlanTeamplateView extends StatelessWidget {
     }
 
     return DefaultLayout(
-        child: Column(children: [
-      AppBar(
-        backgroundColor: PlanitColors.transparent,
-        title: PlanitText(template.title,
-            style: PlanitTypos.body2.copyWith(color: PlanitColors.black01)),
+      title: templateName,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 20),
+            child: ListView.separated(
+              shrinkWrap: true,
+              itemCount: template.templateDetails.length,
+              separatorBuilder: (context, index) => SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                return TemplateDetailCard(
+                  templateDetail: template.templateDetails[index],
+                );
+              },
+            ),
+          ),
+        ],
       ),
-      Padding(
-        padding: const EdgeInsets.only(top: 32),
-        child: ListView.builder(
-          shrinkWrap: true,
-          itemCount: template.templateDetails.length,
-          itemBuilder: (context, index) {
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: TemplateDetailCard(
-                templateDetail: template.templateDetails[index],
-              ),
-            );
-          },
-        ),
-      ),
-    ]));
+    );
   }
 }

--- a/lib/ui/plan/plan_template/plan_template_detail_view.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:planit/repository/plan/plan_repository.dart';
-import 'package:planit/repository/task/model/task_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
@@ -12,8 +10,6 @@ import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/component/task_card.dart';
-import 'package:planit/ui/plan/component/template_detail_card.dart';
-import 'package:planit/ui/plan/plan_main/plan_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view_model.dart';
 

--- a/lib/ui/plan/plan_template/plan_template_detail_view_model.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:planit/core/loading_status.dart';
 import 'package:planit/core/repository_result.dart';
 import 'package:planit/repository/plan/model/plan_create_model.dart';
 import 'package:planit/repository/plan/plan_repository.dart';

--- a/lib/ui/plan/plan_template/plan_template_detail_view_model.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view_model.dart
@@ -62,8 +62,11 @@ class PlanTemplateViewModel extends StateNotifier<PlanTemplateState> {
     }
 
     for (final task in templateDetail.tasks) {
-      final taskAddResult =
-          await _taskRepository.addTask(title: task.title, planId: planId);
+      final taskAddResult = await _taskRepository.addTask(
+        title: task.title,
+        planId: planId,
+        taskType: 'ALL',
+      );
 
       if (taskAddResult is FailureRepositoryResult) {
         // 실패 시 처리 (예: 에러 반환, 로그 기록 등)


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 플랜 관련 화면 레이아웃 위주로만 시안과 일치하게 다듬었어요
- 태스크 생성이 되어야 UI 테스트가 돼서, 변경된 태스크 생성 API도 반영했습니다
- 템플릿 화면은 덜 구현된 거 같아서 크게 건들지 않았습니다
   - DefaultLayout의 AppBar를 활용 안하고 계신 거 같아서 AppBar 설정만 변경했어요!

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 사용해보면서 개선 필요하다고 생각된 부분입니다!
   - 플랜 생성 시 'PlanView' 새로고침
   - 플랙 삭제 시 'PlanDetailView' 새로고침
   - 플랜 제작 시, 목표일 초기화할 수 있도록
      - DatePicker로 선택한 값 지울 수 있도록,, 선택값이기 때문에 유저가 입력을 안 할 수도, 이미 한 입력을 지울 수도 있어야 함
   - 모든 viewModel에 autoDispose 적용



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 전체 플랜 목록을 페이지네이션으로 볼 수 있는 새로운 화면이 추가되었습니다.

* **기능 개선**
  * 플랜 생성, 상세, 템플릿 등 주요 화면의 UI 레이아웃과 스타일이 더욱 일관성 있게 개선되었습니다.
  * 할 일 생성 시 입력값 유효성 및 버튼 활성화 등 사용성 향상이 이루어졌습니다.
  * 하단 시트, 버튼, 리스트 등 다양한 컴포넌트의 배치와 스타일이 개선되었습니다.

* **버그 수정**
  * 키보드가 나타날 때 하단 시트가 가려지지 않도록 패딩이 추가되었습니다.

* **리팩터링 및 기타**
  * 불필요한 import 정리 및 코드 구조 개선이 다수 이루어졌습니다.
  * 일부 API 요청 방식이 쿼리 파라미터에서 구조화된 요청 본문으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->