### PR TITLE
[Fix] 메인 에러

### DIFF
--- a/android/fastlane/report.xml
+++ b/android/fastlane/report.xml
@@ -5,17 +5,24 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.0013466">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.0024541">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: cd .. &amp;&amp; fvm flutter build apk --release" time="59.6678525">
+      <testcase classname="fastlane.lanes" name="1: cd .. &amp;&amp; fvm flutter build apk --release" time="160.9366695">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: firebase_app_distribution" time="267.96881">
+      <testcase classname="fastlane.lanes" name="2: firebase_app_distribution" time="78.6551787">
+        
+      </testcase>
+    
+      
+      <testcase classname="fastlane.lanes" name="3: slack" time="1.2882008">
+        
+          <failure message="C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/actions/actions_helper.rb:67:in `execute_action&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `chdir&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `execute_action&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing&apos;&#10;Fastfile:19:in `block (2 levels) in parsing_binding&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/lane.rb:41:in `call&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:45:in `chdir&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:45:in `execute&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/lane_manager.rb:46:in `cruise_lane&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/command_line_handler.rb:34:in `handle&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:363:in `run&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:43:in `start&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off&apos;&#10;C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fastlane-2.228.0/bin/fastlane:23:in `&lt;top (required)&gt;&apos;&#10;C:/Ruby32-x64/bin/fastlane:32:in `load&apos;&#10;C:/Ruby32-x64/bin/fastlane:32:in `&lt;main&gt;&apos;&#10;&#10;Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile, this is usually caused by a misspelled or changed group/channel name or an expired SLACK_URL" />
         
       </testcase>
     

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
@@ -16,6 +17,12 @@ Future<void> main() async {
     nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY'],
     javaScriptAppKey: dotenv.env['KAKAO_JAVASCRIPT_APP_KEY'],
   );
+
+  // 화면 세로로 고정
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
 
   runApp(
     ProviderScope(

--- a/lib/ui/login/tos_view.dart
+++ b/lib/ui/login/tos_view.dart
@@ -73,7 +73,7 @@ class TosView extends HookConsumerWidget {
                       PlanitWebView.routeName,
                       extra: WebViewParams(
                         title: '서비스 이용약관',
-                        url: PlanitUrls.termOfInfo,
+                        url: PlanitUrls.termOfUse,
                       ),
                     ),
                   ),
@@ -85,7 +85,7 @@ class TosView extends HookConsumerWidget {
                       PlanitWebView.routeName,
                       extra: WebViewParams(
                         title: '개인정보처리방침',
-                        url: PlanitUrls.termOfUse,
+                        url: PlanitUrls.termOfInfo,
                       ),
                     ),
                   ),

--- a/lib/ui/main/component/route_switch_banner.dart
+++ b/lib/ui/main/component/route_switch_banner.dart
@@ -45,13 +45,9 @@ class RouteSwitchBanner extends StatelessWidget {
               children: [
                 Text(
                   isSlow ? '천천히 루트' : '열정 루트',
-                  style: isSlow
-                      ? PlanitTypos.title2.copyWith(
-                          color: PlanitColors.black01,
-                        )
-                      : PlanitTypos.title1.copyWith(
-                          color: PlanitColors.black01,
-                        ),
+                  style: PlanitTypos.title2.copyWith(
+                    color: PlanitColors.black01,
+                  ),
                 ),
                 Text(
                   '오늘도 한 걸음이면 돼요.',

--- a/lib/ui/main/component/task_widget.dart
+++ b/lib/ui/main/component/task_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:planit/repository/main/model/main_plan_model.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
@@ -95,10 +96,14 @@ class _Task extends StatelessWidget {
                         ),
                         SizedBox(height: 16.0),
                         GestureDetector(
-                          onTap: () => onCheckboxTap(
-                            taskId: task.taskId,
-                            isCurrentCompleted: task.isCompleted,
-                          ),
+                          onTap: () {
+                            // 바텀시트 닫은 후에 완료 처리
+                            context.pop();
+                            onCheckboxTap(
+                              taskId: task.taskId,
+                              isCurrentCompleted: task.isCompleted,
+                            );
+                          },
                           child: Padding(
                             padding: const EdgeInsets.symmetric(vertical: 16.0),
                             child: PlanitText(

--- a/lib/ui/main/component/task_widget.dart
+++ b/lib/ui/main/component/task_widget.dart
@@ -104,8 +104,12 @@ class _Task extends StatelessWidget {
                               isCurrentCompleted: task.isCompleted,
                             );
                           },
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 16.0,
+                              horizontal: 20,
+                            ),
+                            color: PlanitColors.transparent,
                             child: PlanitText(
                               '네',
                               style: PlanitTypos.body2.copyWith(
@@ -120,8 +124,12 @@ class _Task extends StatelessWidget {
                         ),
                         GestureDetector(
                           onTap: () => Navigator.of(context).pop(),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 16.0,
+                              horizontal: 20,
+                            ),
+                            color: PlanitColors.transparent,
                             child: PlanitText(
                               '아니오',
                               style: PlanitTypos.body2.copyWith(

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -51,12 +51,14 @@ class MainView extends HookConsumerWidget {
 
     // taskStatus를 감지하여, nothing에서 partial로 변경될 때에만 첫달성 화면 노출
     useValueChanged<TaskStatus, void>(state.taskStatus, (oldValue, _) {
-      if (oldValue == TaskStatus.nothing && state.taskStatus == TaskStatus.partial) {
+      // 이전 값이 nothing이고, 변화된 값이 nothing이 아닐 때
+      if (oldValue == TaskStatus.nothing &&
+          state.taskStatus != TaskStatus.nothing) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           Navigator.of(context).push(
             MaterialPageRoute(
               builder: (context) => FirstCompleteView(
-                consecutiveDays: 102,
+                consecutiveDays: state.consecutiveDay,
               ),
             ),
           );

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -196,7 +196,7 @@ class MainViewModel extends StateNotifier<MainState> {
         if (mounted) {
           state = state.copyWith(
             loadingStatus: LoadingStatus.success,
-            consecutiveDay: result.data.currentConsecutiveDays,
+            consecutiveDay: result.data.currentConsecutiveDays + 1,
           );
         }
       case FailureRepositoryResult<ConsecutiveDaysModel>():

--- a/lib/ui/main/main_view_model.dart
+++ b/lib/ui/main/main_view_model.dart
@@ -61,12 +61,25 @@ class MainViewModel extends StateNotifier<MainState> {
       return;
     }
 
-    final DateTime? lastCompleteTaskDate = stringToDateTime(
+    final DateTime? lastCompleteTaskDateTime = stringToDateTime(
       lastCompleteTaskDateString,
     );
-    final DateTime today = DateTime.now();
+    final DateTime todayDatetime = DateTime.now();
+
+    // 시각 포함하지 않고 날짜만 비교
+    final lastDate = DateTime(
+      lastCompleteTaskDateTime!.year,
+      lastCompleteTaskDateTime.month,
+      lastCompleteTaskDateTime.day,
+    );
+    final today = DateTime(
+      todayDatetime.year,
+      todayDatetime.month,
+      todayDatetime.day,
+    );
+
     // 오늘 이전이 아니라면 == 오늘이거나, 오늘 이후라면>첫 달성을 한 것
-    if (!lastCompleteTaskDate!.isBefore(today)) {
+    if (!lastDate.isBefore(today)) {
       state = state.copyWith(taskStatus: TaskStatus.partial);
     } else {
       state = state.copyWith(taskStatus: TaskStatus.nothing);

--- a/lib/ui/main/view/first_complete_view.dart
+++ b/lib/ui/main/view/first_complete_view.dart
@@ -201,13 +201,8 @@ class _TextBox extends StatelessWidget {
           ),
           SizedBox(height: 8.0),
           PlanitText(
-            '남은 일들도',
-            style: PlanitTypos.body1.copyWith(
-              color: PlanitColors.black03,
-            ),
-          ),
-          PlanitText(
-            '빠르게 마감해볼까요?',
+            '남은 일들도\n빠르게 마감해볼까요?',
+            textAlign: TextAlign.center,
             style: PlanitTypos.body1.copyWith(
               color: PlanitColors.black03,
             ),

--- a/lib/ui/mypage/component/mypage_bottom_info_widget.dart
+++ b/lib/ui/mypage/component/mypage_bottom_info_widget.dart
@@ -34,7 +34,7 @@ class MypageBottomInfoWidget extends StatelessWidget {
                   PlanitWebView.routeName,
                   extra: WebViewParams(
                     title: '이용약관',
-                    url: PlanitUrls.termOfInfo,
+                    url: PlanitUrls.termOfUse,
                   ),
                 ),
                 child: PlanitText(
@@ -49,7 +49,7 @@ class MypageBottomInfoWidget extends StatelessWidget {
                   PlanitWebView.routeName,
                   extra: WebViewParams(
                     title: '개인정보처리방침',
-                    url: PlanitUrls.termOfUse,
+                    url: PlanitUrls.termOfInfo,
                   ),
                 ),
                 child: PlanitText(

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -8,7 +8,8 @@ import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
 import 'package:planit/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view_model.dart';
-import 'package:planit/ui/plan/plan_main/plan_view.dart';
+
+import '../../../../archiving/archiving_complete/archiving_complete_view.dart';
 
 class PlanMoreBottomSheet extends HookConsumerWidget {
   final int planId;


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 태스크 달성 UI가, 태스크 완료 바텀시트 내려간 후 노출되도록 수정
- 첫 달성 화면 안 뜨는 케이스 보완
- 메인 연속일을 실제 연속일 +1로 노출
- 태스크 완료 바텀시트 터치영역이 글자로 한정되어 잘 안눌려,  컨테이너로 터치영역 확장
- 앱 세로모드로 고정
- 약관 URL 꼬임 해결
- 메인 '열정 루트' 텍스트 스타일 title2로 변경

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 화이팅~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 서비스 이용약관 및 개인정보처리방침, 이용약관 링크의 URL 연결 오류를 수정하여 올바른 문서로 이동하도록 개선했습니다.
  * 첫 완료 화면에서 남은 일 관련 문구가 한 줄로 합쳐지고 중앙 정렬로 표시되도록 수정했습니다.
  * 체크박스 확인 시 바텀시트가 먼저 닫히도록 동작 순서를 개선했습니다.

* **기능 개선**
  * 앱 화면 방향이 세로(포트레이트)로 고정됩니다.
  * 첫 완료 화면 진입 조건이 더 넓어지고, 연속 완료 일수가 동적으로 반영됩니다.
  * 연속 완료 일수 계산이 1일 더해져 정확하게 표시됩니다.

* **UI 개선**
  * 확인/취소 버튼의 패딩 및 배경 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->