### PR TITLE
[PL-124] Fix: today_tasks_response 루틴타임 null 처리

### DIFF
--- a/lib/data_source/main/reponse_body/today_tasks_response_body.dart
+++ b/lib/data_source/main/reponse_body/today_tasks_response_body.dart
@@ -43,13 +43,13 @@ class TodayPlanResponseBody {
 class TaskStatusResponseBody {
   final int taskId;
   final String title;
-  final String routineTime;
+  final String? routineTime;
   final bool isCompleted;
 
   TaskStatusResponseBody({
     required this.taskId,
     required this.title,
-    required this.routineTime,
+    this.routineTime,
     required this.isCompleted,
   });
 

--- a/lib/data_source/main/reponse_body/today_tasks_response_body.g.dart
+++ b/lib/data_source/main/reponse_body/today_tasks_response_body.g.dart
@@ -54,7 +54,7 @@ TaskStatusResponseBody _$TaskStatusResponseBodyFromJson(
     TaskStatusResponseBody(
       taskId: (json['taskId'] as num).toInt(),
       title: json['title'] as String,
-      routineTime: json['routineTime'] as String,
+      routineTime: json['routineTime'] as String?,
       isCompleted: json['isCompleted'] as bool,
     );
 


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

-  routIneTime 이 null일때 
<img width="1043" height="234" alt="image" src="https://github.com/user-attachments/assets/0c8236d9-75ec-41dc-97e3-e8c21fdccc4d" />

- today_tasks_response 안에 routineTime String? 으로 바꿨습니다


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

-  ㄳ합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일부 작업(Task)에서 `routineTime` 값이 없거나(null) 누락된 경우에도 정상적으로 표시 및 처리가 가능하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->