### PR TITLE
Pl 14/fix/chang/plan issue

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -126,12 +126,13 @@ class AppRouter {
                 },
               ),
               GoRoute(
-                  path: 'detail/:planStatus/:planId/:dDay',
+                  path: 'detail/:planId',
                   name: 'plan_detail',
                   pageBuilder: (context, state) {
-                    final planStatus = state.pathParameters['planStatus']!;
+                    final planStatus = state.uri.queryParameters['planStatus']!;
                     final planIdStr = state.pathParameters['planId']!;
-                    final dDay = state.pathParameters['dDay']!;
+                    final dDay = state.uri.queryParameters['dDay'];
+
                     final planId = int.parse(planIdStr);
                     return NoTransitionPage(
                       child: PlanDetailView(

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -126,14 +126,16 @@ class AppRouter {
                 },
               ),
               GoRoute(
-                  path: 'detail/:planStatus/:planId',
+                  path: 'detail/:planStatus/:planId/:dDay',
                   name: 'plan_detail',
                   pageBuilder: (context, state) {
                     final planStatus = state.pathParameters['planStatus']!;
                     final planIdStr = state.pathParameters['planId']!;
+                    final dDay = state.pathParameters['dDay']!;
                     final planId = int.parse(planIdStr);
                     return NoTransitionPage(
                       child: PlanDetailView(
+                        dDay: dDay,
                         planId: planId,
                         planStatus: planStatus,
                       ),
@@ -145,12 +147,14 @@ class AppRouter {
                 pageBuilder: (context, state) {
                   final planIdStr = state.uri.queryParameters['planId'];
                   final planStatus = state.uri.queryParameters['planStatus'];
+                  final dDay = state.uri.queryParameters['dDay'];
                   final planId =
                       planIdStr != null ? int.tryParse(planIdStr) : null;
                   return NoTransitionPage(
                     child: PlanCreateView(
                       planId: planId,
                       planStatus: planStatus,
+                      dDay: dDay,
                     ), // null 허용
                   );
                 },

--- a/lib/ui/plan/component/plan_list_card.dart
+++ b/lib/ui/plan/component/plan_list_card.dart
@@ -10,20 +10,28 @@ import 'package:planit/ui/plan/component/plan_main_chip.dart';
 class PlanListCard extends StatelessWidget {
   final PlanModel plan;
   final String planStatus;
+  final VoidCallback? needsRefresh;
 
-  const PlanListCard({super.key, required this.plan, required this.planStatus});
+  const PlanListCard(
+      {super.key,
+      required this.plan,
+      required this.planStatus,
+      this.needsRefresh});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        context.pushNamed(
+      onTap: () async {
+        final result = await context.pushNamed(
           'plan_detail',
           pathParameters: {
             'planId': plan.planId.toString(),
-            'planStatus': planStatus, 
+            'planStatus': planStatus,
           },
         );
+        if (result == true && needsRefresh != null) {
+          needsRefresh!();
+        }
       },
       child: Container(
           decoration: BoxDecoration(

--- a/lib/ui/plan/component/plan_list_card.dart
+++ b/lib/ui/plan/component/plan_list_card.dart
@@ -24,14 +24,12 @@ class PlanListCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        final result = await context.pushNamed(
-          'plan_detail',
-          pathParameters: {
-            'planId': plan.planId.toString(),
-            'planStatus': planStatus,
-            'dDay': dDay ?? ''
-          },
-        );
+        final result = await context.pushNamed('plan_detail', pathParameters: {
+          'planId': plan.planId.toString(),
+        }, queryParameters: {
+          'dDay': dDay,
+          'planStatus': planStatus,
+        });
         if (result == true && needsRefresh != null) {
           needsRefresh!();
         }

--- a/lib/ui/plan/component/plan_list_card.dart
+++ b/lib/ui/plan/component/plan_list_card.dart
@@ -10,11 +10,13 @@ import 'package:planit/ui/plan/component/plan_main_chip.dart';
 class PlanListCard extends StatelessWidget {
   final PlanModel plan;
   final String planStatus;
+  final String? dDay;
   final VoidCallback? needsRefresh;
 
   const PlanListCard(
       {super.key,
       required this.plan,
+      required this.dDay,
       required this.planStatus,
       this.needsRefresh});
 
@@ -27,6 +29,7 @@ class PlanListCard extends StatelessWidget {
           pathParameters: {
             'planId': plan.planId.toString(),
             'planStatus': planStatus,
+            'dDay': dDay ?? ''
           },
         );
         if (result == true && needsRefresh != null) {

--- a/lib/ui/plan/component/task_card.dart
+++ b/lib/ui/plan/component/task_card.dart
@@ -11,7 +11,7 @@ class TaskCard extends StatelessWidget {
   final String taskType;
   final int taskId;
   final bool showMore;
-  final VoidCallback? onTaskDeleted; //삭제 성공시 DetailView 새로고침을 위함
+  final VoidCallback? needsRefresh; //삭제 성공시 DetailView 새로고침을 위함
 
   const TaskCard({
     super.key,
@@ -19,7 +19,7 @@ class TaskCard extends StatelessWidget {
     required this.taskId,
     required this.taskType,
     this.showMore = true,
-    this.onTaskDeleted,
+    this.needsRefresh,
   });
 
   @override
@@ -75,7 +75,7 @@ class TaskCard extends StatelessWidget {
                         },
                       );
                       if (result == true) {
-                        onTaskDeleted?.call();
+                        needsRefresh?.call();
                       }
                     },
                     child: SvgPicture.asset(Assets.more),

--- a/lib/ui/plan/component/template_list.dart
+++ b/lib/ui/plan/component/template_list.dart
@@ -42,8 +42,10 @@ class TemplateList extends StatelessWidget {
               );
             },
             child: Padding(
-              // 첫번째 아이템에만 좌측 패딩
-              padding: EdgeInsets.only(left: index == 0 ? 20 : 0),
+              // 첫번째 아이템에만 좌측 패딩, 마지막 아이템에만 오른쪽 패딩
+              padding: EdgeInsets.only(
+                  left: index == 0 ? 20 : 0,
+                  right: index == templateImage.length - 1 ? 20 : 0),
               child: SvgPicture.asset(
                 templateImage[index],
                 height: 112,

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -5,6 +5,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
@@ -377,6 +378,9 @@ class PlanCreateView extends HookConsumerWidget {
                   width: double.infinity,
                   child: PlanitButton(
                     onPressed: () async {
+                      if (state.loadingStatus == LoadingStatus.loading) {
+                        return;
+                      }
                       viewmodel.updateClickedNext();
                       // 방금 상태를 변경했기 때문에, 최신 상태를 ref.read()로 즉시 가져옴
                       final latestState = ref.read(planViewModelProvider);

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -394,7 +394,7 @@ class PlanCreateView extends HookConsumerWidget {
                               if (success) {
                                 toast.showToast(
                                     child: PlanitToast(label: '플랜이 수정됐어요!'));
-                                context.goNamed(RootTab.routeName);
+                                context.pop(true);
                               } else {
                                 toast.showToast(
                                     child: PlanitToast(label: '플랜 수정에 실패했어요.'));

--- a/lib/ui/plan/plan_create/plan_create_view.dart
+++ b/lib/ui/plan/plan_create/plan_create_view.dart
@@ -25,9 +25,10 @@ import 'package:planit/ui/plan/plan_create/plan_create_view_model.dart';
 class PlanCreateView extends HookConsumerWidget {
   static String get routeName => 'plan_create';
   final int? planId;
+  final String? dDay;
   final String? planStatus;
 
-  const PlanCreateView({super.key, this.planId, this.planStatus});
+  const PlanCreateView({super.key, this.planId, this.planStatus, this.dDay});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -78,6 +79,11 @@ class PlanCreateView extends HookConsumerWidget {
       if (planStatus != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           viewmodel.updatePlanStatus(planStatus!);
+        });
+      }
+      if (dDay != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          viewmodel.calculateFinalDate(dDay!);
         });
       }
       return null;

--- a/lib/ui/plan/plan_create/plan_create_view_model.dart
+++ b/lib/ui/plan/plan_create/plan_create_view_model.dart
@@ -68,6 +68,23 @@ class PlanCreateViewModel extends StateNotifier<PlanCreateState> {
     }
   }
 
+  void calculateFinalDate(String dDayString) {
+    final dDayValue =
+        int.tryParse(dDayString.replaceAll('D-', '').replaceAll('D+', ''));
+
+    if (dDayValue == null) {
+      return; 
+    }
+
+    final now = DateTime.now();
+    final targetDate = now.add(Duration(days: dDayValue));
+
+    final finalDay =
+        '${targetDate.year.toString().padLeft(4, '0')}-${targetDate.month.toString().padLeft(2, '0')}-${targetDate.day.toString().padLeft(2, '0')}';
+    state = state.copyWith(selectedDate: finalDay);
+    return;
+  }
+
   Future<void> getPlanCreateInfo(int planId) async {
     state = state.copyWith(loadingStatus: LoadingStatus.loading);
     final result = await _planRepository.getPlanDetailByPlanId(planId);

--- a/lib/ui/plan/plan_create/plan_create_view_model.dart
+++ b/lib/ui/plan/plan_create/plan_create_view_model.dart
@@ -68,21 +68,48 @@ class PlanCreateViewModel extends StateNotifier<PlanCreateState> {
     }
   }
 
-  void calculateFinalDate(String dDayString) {
-    final dDayValue =
-        int.tryParse(dDayString.replaceAll('D-', '').replaceAll('D+', ''));
+  // void calculateFinalDate(String dDayString) {
+  //   final dDayValue =
+  //       int.tryParse(dDayString.replaceAll('D-', '').replaceAll('D+', ''));
 
-    if (dDayValue == null) {
-      return; 
+  //   if (dDayValue == null) {
+  //     return;
+  //   }
+
+  //   final now = DateTime.now();
+  //   final targetDate = now.add(Duration(days: dDayValue));
+
+  //   final finalDay =
+  //       '${targetDate.year.toString().padLeft(4, '0')}-${targetDate.month.toString().padLeft(2, '0')}-${targetDate.day.toString().padLeft(2, '0')}';
+  //   state = state.copyWith(selectedDate: finalDay);
+  //   return;
+  // }
+
+  void calculateFinalDate(String dDayString) {
+    final input = dDayString.trim().toUpperCase();
+    final now = DateTime.now();
+
+    // 형식: D-10 / D+3
+    final match = RegExp(r'^D([+-])(\d+)$').firstMatch(input);
+    DateTime targetDate;
+    if (match != null) {
+      final sign = match.group(1)!; // '-' or '+'
+      final days = int.parse(match.group(2)!);
+      // D-10: 10일 남음 → +10
+      // D+3 : 3일 지남 → -3
+      final delta = sign == '-' ? days : -days;
+      targetDate = now.add(Duration(days: delta));
+    } else {
+      // 숫자만 들어오는 경우도 허용
+      final parsed = int.tryParse(input);
+      if (parsed == null) {
+        return;
+      }
+      targetDate = now.add(Duration(days: parsed));
     }
 
-    final now = DateTime.now();
-    final targetDate = now.add(Duration(days: dDayValue));
-
-    final finalDay =
-        '${targetDate.year.toString().padLeft(4, '0')}-${targetDate.month.toString().padLeft(2, '0')}-${targetDate.day.toString().padLeft(2, '0')}';
+    final finalDay = DateFormat('yyyy-MM-dd').format(targetDate);
     state = state.copyWith(selectedDate: finalDay);
-    return;
   }
 
   Future<void> getPlanCreateInfo(int planId) async {

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -37,14 +37,20 @@ class PlanMoreBottomSheet extends HookConsumerWidget {
             Padding(
               padding: const EdgeInsets.only(top: 12),
               child: GestureDetector(
-                onTap: () {
-                  context.pushNamed(
+                onTap: () async {
+                  final result = await context.pushNamed(
                     PlanCreateView.routeName,
                     queryParameters: {
                       'planId': planId.toString(),
                       'planStatus': planStatus
                     },
                   );
+                  if (!context.mounted) {
+                    return;
+                  }
+                  if (result == true) {
+                    context.pop(true);
+                  }
                 },
                 child: PlanitText('플랜 수정', style: PlanitTypos.body2),
               ),

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -40,14 +40,16 @@ class PlanMoreBottomSheet extends HookConsumerWidget {
               padding: const EdgeInsets.only(top: 12),
               child: GestureDetector(
                 onTap: () async {
+                   final params = <String, String>{
+                    'planId': planId.toString(),
+                    'planStatus': planStatus,
+                    if (dDay != null) 'dDay': dDay!,
+                  };
                   final result = await context.pushNamed(
                     PlanCreateView.routeName,
-                    queryParameters: {
-                      'planId': planId.toString(),
-                      'planStatus': planStatus,
-                      'dDay': dDay
-                    },
+                    queryParameters: params,
                   );
+                  
                   if (!context.mounted) {
                     return;
                   }

--- a/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/plan_more/plan_more_bottom_sheet_view.dart
@@ -15,11 +15,13 @@ import '../../../../archiving/archiving_complete/archiving_complete_view.dart';
 
 class PlanMoreBottomSheet extends HookConsumerWidget {
   final int planId;
-  final String planStatus;
-  final String icon;
-  final String title;
+  final String planStatus; //플랜 수정할때 넘겨줘야함
+  final String? dDay; // 플랜 수정할때 넘겨줘야함
+  final String icon; //아카이빙 완료할때 넘겨줘야함
+  final String title; //아카이빙 완료 할때 넘겨줘어함
   const PlanMoreBottomSheet(
       {super.key,
+      required this.dDay,
       required this.title,
       required this.planId,
       required this.planStatus,
@@ -42,7 +44,8 @@ class PlanMoreBottomSheet extends HookConsumerWidget {
                     PlanCreateView.routeName,
                     queryParameters: {
                       'planId': planId.toString(),
-                      'planStatus': planStatus
+                      'planStatus': planStatus,
+                      'dDay': dDay
                     },
                   );
                   if (!context.mounted) {

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_add/task_add_bottom_sheet_view.dart
@@ -60,6 +60,7 @@ class _TaskAddBottomSheetViewState extends State<TaskAddBottomSheetView> {
             ),
             SizedBox(height: 16),
             PlanitTextField(
+              maxLength: 30,
               hintText: '내용을 입력해주세요',
               controller: controller,
             ),

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
@@ -29,6 +29,8 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
       taskEditViewModelProvider(taskId).notifier,
     );
 
+    final showConditionError = useState(false);
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         viewmodel.init();
@@ -188,6 +190,9 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                       GestureDetector(
                         onTap: () {
                           viewmodel.toggleType('HIGH');
+                          if (showConditionError.value) {
+                            showConditionError.value = false;
+                          }
                         },
                         child: PlanitChip(
                           chipColor: state.taskType.contains('HIGH')
@@ -199,6 +204,9 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                       GestureDetector(
                         onTap: () {
                           viewmodel.toggleType('LOW');
+                          if (showConditionError.value) {
+                            showConditionError.value = false;
+                          }
                         },
                         child: PlanitChip(
                           chipColor: state.taskType.contains('LOW')
@@ -210,6 +218,17 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                     ],
                   ),
                 ),
+                // 에러 메시지 표시
+                if (showConditionError.value)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: PlanitText(
+                      '컨디션을 선택해주세요',
+                      style: PlanitTypos.caption.copyWith(
+                        color: PlanitColors.alert,
+                      ),
+                    ),
+                  ),
                 Padding(
                   padding: const EdgeInsets.only(top: 12),
                   // 물음표까지 터치영역 확장
@@ -261,6 +280,11 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                     width: double.infinity,
                     child: PlanitButton(
                       onPressed: () async {
+                        if (state.taskType.isEmpty) {
+                          showConditionError.value = true;
+                          return; 
+                        }
+
                         final result = await viewmodel.saveEditedRoutine();
                         if (!context.mounted) return;
                         if (result) {

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
@@ -259,9 +260,16 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                   child: SizedBox(
                     width: double.infinity,
                     child: PlanitButton(
-                      onPressed: () {
-                        viewmodel.saveEditedRoutine();
-                        Navigator.pop(context);
+                      onPressed: () async {
+                        final result = await viewmodel.saveEditedRoutine();
+                        if (!context.mounted) return;
+                        if (result) {
+                          context.pop(true);
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('수정에 실패했어요.')),
+                          );
+                        }
                       },
                       buttonColor: PlanitButtonColor.black,
                       buttonSize: PlanitButtonSize.large,

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
@@ -280,18 +281,27 @@ class TaskEditBottomSheetView extends HookConsumerWidget {
                     width: double.infinity,
                     child: PlanitButton(
                       onPressed: () async {
+                        if (state.loadingStatus == LoadingStatus.loading) {
+                          return;
+                        }
                         if (state.taskType.isEmpty) {
                           showConditionError.value = true;
-                          return; 
+                          return;
                         }
-
-                        final result = await viewmodel.saveEditedRoutine();
-                        if (!context.mounted) return;
-                        if (result) {
-                          context.pop(true);
-                        } else {
+                        try {
+                          final result = await viewmodel.saveEditedRoutine();
+                          if (!context.mounted) return;
+                          if (result) {
+                            context.pop(true);
+                          } else {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('수정에 실패했어요.')),
+                            );
+                          }
+                        } catch (e) {
+                          if (!context.mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('수정에 실패했어요.')),
+                            const SnackBar(content: Text('오류가 발생했어요.')),
                           );
                         }
                       },

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
@@ -66,8 +66,10 @@ class TaskEditBottomSheetViewModel
       taskType = 'ALL';
     } else if (taskTypeSet.contains('HIGH')) {
       taskType = 'PASSIONATE';
-    } else {
+    } else if (taskTypeSet.contains('LOW')) {
       taskType = 'SLOW';
+    } else {
+      return false;
     }
 
     // 요일 매핑

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_edit/task_edit_bottom_sheet_view_model.dart
@@ -56,7 +56,7 @@ class TaskEditBottomSheetViewModel
     state = state.copyWith(taskType: updated);
   }
 
-  void saveEditedRoutine() async {
+  Future<bool> saveEditedRoutine() async {
     state = state.copyWith(loadingStatus: LoadingStatus.loading);
 
     // taskType 설정
@@ -95,16 +95,18 @@ class TaskEditBottomSheetViewModel
         routineDay: routineDay,
       ),
     );
-    if (!mounted) return;
+    if (!mounted) return false;
     // 결과 처리
     switch (editRoutineResult) {
       case SuccessRepositoryResult():
         state = state.copyWith(loadingStatus: LoadingStatus.success);
+        return true;
       case FailureRepositoryResult():
         state = state.copyWith(
           loadingStatus: LoadingStatus.error,
           errorMessage: '루틴 설정에 실패했어요',
         );
+        return false;
     }
   }
 

--- a/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view.dart
+++ b/lib/ui/plan/plan_detail/bottom_sheet/task_more/task_more_bottom_sheet_view.dart
@@ -26,15 +26,18 @@ class TaskMoreBottomSheetView extends HookConsumerWidget {
           content: Column(
             children: [
               GestureDetector(
-                onTap: () {
-                  context.pop(context);
-                  showModalBottomSheet(
+                onTap: () async {
+                  final result = await showModalBottomSheet(
                     isScrollControlled: true,
                     context: context,
                     builder: (context) => TaskEditBottomSheetView(
                       taskId: taskId,
                     ),
                   );
+                  if (!context.mounted) return;
+                  if (result == true) {
+                    context.pop(true);
+                  }
                 },
                 // 터치 영역 확장 위해 흰색 컨테이너 사용
                 child: Container(
@@ -56,7 +59,7 @@ class TaskMoreBottomSheetView extends HookConsumerWidget {
                   final result = await viewmodel.clickDeleteTask();
                   if (!context.mounted) return;
                   if (result) {
-                    context.pop(true);  // 성공 시 모달 닫으면서 true 전달
+                    context.pop(true); // 성공 시 모달 닫으면서 true 전달
                   } else {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('삭제에 실패했어요.')),

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -19,9 +19,13 @@ import 'package:planit/ui/plan/plan_detail/plan_detail_view_model.dart';
 class PlanDetailView extends HookConsumerWidget {
   final int planId;
   final String planStatus;
+  final String? dDay;
 
   const PlanDetailView(
-      {required this.planId, required this.planStatus, super.key});
+      {required this.planId,
+      required this.planStatus,
+      required this.dDay,
+      super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -104,6 +108,7 @@ class PlanDetailView extends HookConsumerWidget {
                                     return PlanMoreBottomSheet(
                                       title: state.planDetail!.title,
                                       planStatus: planStatus,
+                                      dDay : dDay,
                                       planId: planId,
                                       icon: state.planDetail!.icon,
                                     );

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -132,7 +132,8 @@ class PlanDetailView extends HookConsumerWidget {
                     ),
                     // 동기
                     Padding(
-                      padding: const EdgeInsets.only(top: 4.0, bottom: 40),
+                      padding: const EdgeInsets.symmetric(horizontal: 20)
+                          .copyWith(top: 4, bottom: 40),
                       child: PlanitText(
                         state.planDetail!.motivation,
                         style: PlanitTypos.body3.copyWith(

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -152,7 +152,7 @@ class PlanDetailView extends HookConsumerWidget {
                             title: item.title,
                             taskType: item.taskType,
                             taskId: item.taskId,
-                            onTaskDeleted: () {
+                            needsRefresh: () {
                               viewModel.init();
                             },
                           ),

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -141,23 +141,24 @@ class PlanDetailView extends HookConsumerWidget {
                       ),
                     ),
                     // 태스크 리스트
-                    ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: state.planDetail!.tasks.length,
-                      itemBuilder: (context, index) {
-                        final item = state.planDetail!.tasks[index];
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 12),
-                          child: TaskCard(
-                            title: item.title,
-                            taskType: item.taskType,
-                            taskId: item.taskId,
-                            needsRefresh: () {
-                              viewModel.init();
-                            },
-                          ),
-                        );
-                      },
+                    Expanded(
+                      child: ListView.builder(
+                        itemCount: state.planDetail!.tasks.length,
+                        itemBuilder: (context, index) {
+                          final item = state.planDetail!.tasks[index];
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: TaskCard(
+                              title: item.title,
+                              taskType: item.taskType,
+                              taskId: item.taskId,
+                              needsRefresh: () {
+                                viewModel.init();
+                              },
+                            ),
+                          );
+                        },
+                      ),
                     ),
                   ],
                 ),

--- a/lib/ui/plan/plan_detail/plan_detail_view.dart
+++ b/lib/ui/plan/plan_detail/plan_detail_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
 import 'package:planit/theme/planit_colors.dart';
@@ -96,8 +97,8 @@ class PlanDetailView extends HookConsumerWidget {
                             top: 8,
                             right: 20,
                             child: GestureDetector(
-                              onTap: () {
-                                showModalBottomSheet(
+                              onTap: () async {
+                                final result = await showModalBottomSheet(
                                   context: context,
                                   builder: (context) {
                                     return PlanMoreBottomSheet(
@@ -108,6 +109,12 @@ class PlanDetailView extends HookConsumerWidget {
                                     );
                                   },
                                 );
+                                if (!context.mounted) {
+                                  return;
+                                }
+                                if (result == true) {
+                                  context.pop(true);
+                                }
                               },
                               child: SvgPicture.asset(
                                 Assets.more,

--- a/lib/ui/plan/plan_main/plan_all_view.dart
+++ b/lib/ui/plan/plan_main/plan_all_view.dart
@@ -77,6 +77,7 @@ class _PlanAllViewState extends State<PlanAllView> {
                     separatorBuilder: (context, index) => SizedBox(height: 12),
                     itemBuilder: (context, index) {
                       return PlanListCard(
+                        dDay: plans[index].dday,
                         plan: plans[index],
                         planStatus: 'PAUSED',
                       );

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -39,7 +39,9 @@ class PlanView extends HookConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            BuildAppBar(viewmodel: viewmodel,),
+            BuildAppBar(
+              viewmodel: viewmodel,
+            ),
             SizedBox(height: 20),
             // 진행 중인 플랜
             if (state.activePlans.isNotEmpty)
@@ -47,6 +49,7 @@ class PlanView extends HookConsumerWidget {
                 title: '진행 중인 플랜',
                 plans: state.activePlans,
                 planStatus: 'IN_PROGRESS',
+                needsRefresh: viewmodel.init,
               ),
             // 잠시 중단한 플랜
             if (state.pausePlans.isNotEmpty)
@@ -59,6 +62,7 @@ class PlanView extends HookConsumerWidget {
                   title: '잠시 중단한 플랜',
                   plans: state.pausePlans,
                   planStatus: 'PAUSED',
+                  needsRefresh: viewmodel.init,
                 ),
               ),
             // 템플릿 텍스트
@@ -120,11 +124,13 @@ class _PlanList extends StatelessWidget {
   final String title;
   final List<PlanModel> plans;
   final String planStatus;
+  final VoidCallback? needsRefresh;
 
   const _PlanList({
     required this.title,
     required this.plans,
     required this.planStatus,
+    this.needsRefresh,
   });
 
   @override
@@ -152,6 +158,7 @@ class _PlanList extends StatelessWidget {
             itemBuilder: (context, index) {
               final item = plans[index];
               return PlanListCard(
+                needsRefresh: needsRefresh,
                 planStatus: planStatus,
                 plan: item,
               );

--- a/lib/ui/plan/plan_main/plan_view.dart
+++ b/lib/ui/plan/plan_main/plan_view.dart
@@ -158,6 +158,7 @@ class _PlanList extends StatelessWidget {
             itemBuilder: (context, index) {
               final item = plans[index];
               return PlanListCard(
+                dDay: item.dday,
                 needsRefresh: needsRefresh,
                 planStatus: planStatus,
                 plan: item,


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

-  테스크 수정 후 새로고침 
    -  taskCard -> taskMoreBottomSheet -> taskEditBottomSheet  순으로 화면이 중첩되어 있고,
    - taskEditBottomSheet가 수정되고 종료될 때 true 값을 taskCard까지 넘겨 줘서 refresh 되게 해줬습니다
   <br>
- 테스크 > 루틴 설정 > 컨디션 미선택 막음
   - 원래는 아무것도 선택했을 때 else문으로 넘어가서 taskType이 SLOW로 저장
   - taskStatus 미선택시 저장안되고 빨간 글씨로 컨디션 선택해주세요 뜸. 그 후 taskType 선택하면 저장되게 바꿨습니다
   <br>
- 플랜디테일 > task 길어질때 스크롤, 오버플로우 방지
    - shrinkWrap 때문에 스크롤 안되고 오버플로우 됐는데, Expanded감싸 해결했습니다.
       <br>
-  플랜 > 템플릿 리스트 rightPadding 추가했습니다.
   <br>
-  task 이름 길이 30자로 제한했습니다.
  <br>

-  플랜 디테일 > 동기 글씨 horizonal padding 추가했습니다
   <br>
- 플랜 수정 후 새로고침 되게 바꿨습니다.
    - planListCard -> planDetailView -> PlanDetailMoreBottomSheet -> PlanCreateView 순으로 화면이 중첩되어있고
    - PlanCreateView에서 수정되고 종료될때 true값을 planListCard까지 넘겨줘서 refresh 되게 해줬습니다.
       <br>
- 플랜 수정 > 목표일 불러옴 
    - planMain에서 불러오는 dDay를 planView -> planDetailView -> planMoreBottomSheet -> planCretate 순으로 넘겨서 
    - 현재 날짜와 dDay를 참고해 종료일을 표시했습니다
<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- ㄳ합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 플랜 D-Day 지원: 목록→상세→수정/생성으로 D-Day 전달 및 생성 화면에서 D-Day로 목표 날짜 자동 계산(D-/D+ 형식 지원).
- 개선
  - 상세/수정/생성 내비게이션이 결과 기반으로 동작해 저장/수정 성공 시 이전 화면 자동 새로고침.
  - 작업 수정 시 컨디션 미선택 경고와 저장 실패/오류 스낵바 안내.
  - 작업 추가 입력 30자 제한, 템플릿 리스트 좌우 패딩 보강, 상세 레이아웃 개선.
- 기타
  - 카드/리스트에 새로고침 콜백 흐름 추가 및 중복 제출 방지(로딩 상태 가드).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->