### PR TITLE
[Fix] 메인, 템플릿 에러 및 추가 요구사항 반영

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -25,7 +25,6 @@ import 'package:planit/ui/onboarding/onboarding_view.dart';
 import 'package:planit/ui/plan/plan_create/plan_create_view.dart';
 import 'package:planit/ui/plan/plan_detail/plan_detail_view.dart';
 import 'package:planit/ui/plan/plan_main/plan_all_view.dart';
-import 'package:planit/ui/plan/plan_main/plan_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_teamplate_view.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view.dart';
@@ -104,139 +103,129 @@ class AppRouter {
               ),
             ],
           ),
+          //플랜
           GoRoute(
-            path: 'plan',
-            name: PlanView.routeName,
+            path: 'all/:isActive',
+            name: PlanAllView.routeName,
+            pageBuilder: (context, state) {
+              final planList = state.extra as List<PlanModel>? ?? [];
+              final isActiveStr = state.pathParameters['isActive']!;
+              final isActive = bool.parse(isActiveStr);
+              return NoTransitionPage(
+                  child: PlanAllView(
+                planList: planList,
+                isActive: isActive,
+              ));
+            },
+          ),
+          GoRoute(
+              path: 'detail/:planStatus/:planId',
+              name: 'plan_detail',
+              pageBuilder: (context, state) {
+                final planStatus = state.pathParameters['planStatus']!;
+                final planIdStr = state.pathParameters['planId']!;
+                final planId = int.parse(planIdStr);
+                return NoTransitionPage(
+                  child: PlanDetailView(
+                    planId: planId,
+                    planStatus: planStatus,
+                  ),
+                );
+              }),
+          GoRoute(
+            path: 'create',
+            name: PlanCreateView.routeName,
+            pageBuilder: (context, state) {
+              final planIdStr = state.uri.queryParameters['planId'];
+              final planStatus = state.uri.queryParameters['planStatus'];
+              final planId = planIdStr != null ? int.tryParse(planIdStr) : null;
+              return NoTransitionPage(
+                child: PlanCreateView(
+                  planId: planId,
+                  planStatus: planStatus,
+                ), // null 허용
+              );
+            },
+          ),
+          GoRoute(
+              path: 'template/:templateName',
+              name: PlanTeamplateView.routeName,
+              pageBuilder: (context, state) {
+                final templateName = state.pathParameters['templateName']!;
+                return NoTransitionPage(
+                  child: PlanTeamplateView(
+                    templateName: templateName,
+                  ),
+                );
+              }),
+          GoRoute(
+              path: '/templateDetail',
+              name: PlanTemplateDetailView.routeName,
+              pageBuilder: (context, state) {
+                final templateDetail = state.extra as PlanTemplateDetail;
+                return NoTransitionPage(
+                    child:
+                        PlanTemplateDetailView(templateDetai: templateDetail));
+              }),
+          GoRoute(
+            path: 'archiving',
+            name: ArchivingView.routeName,
             pageBuilder: (context, state) => NoTransitionPage(
-              child: PlanView(), // Plan 목록이나 메인
+              child: ArchivingView(),
             ),
             routes: [
               GoRoute(
-                path: 'all/:isActive',
-                name: PlanAllView.routeName,
-                pageBuilder: (context, state) {
-                  final planList = state.extra as List<PlanModel>? ?? [];
-                  final isActiveStr = state.pathParameters['isActive']!;
-                  final isActive = bool.parse(isActiveStr);
-                  return NoTransitionPage(
-                      child: PlanAllView(
-                    planList: planList,
-                    isActive: isActive,
-                  ));
-                },
-              ),
-              GoRoute(
-                  path: 'detail/:planStatus/:planId',
-                  name: 'plan_detail',
+                  path: 'archivingDetail/:planId',
+                  name: ArchivingDetailView.routeName,
                   pageBuilder: (context, state) {
-                    final planStatus = state.pathParameters['planStatus']!;
                     final planIdStr = state.pathParameters['planId']!;
                     final planId = int.parse(planIdStr);
                     return NoTransitionPage(
-                      child: PlanDetailView(
+                      child: ArchivingDetailView(
                         planId: planId,
-                        planStatus: planStatus,
                       ),
                     );
                   }),
               GoRoute(
-                path: 'create',
-                name: PlanCreateView.routeName,
+                path: 'archivingRestart/:planId/:title',
+                name: ArchivingRestartView.routeName,
                 pageBuilder: (context, state) {
-                  final planIdStr = state.uri.queryParameters['planId'];
-                  final planStatus = state.uri.queryParameters['planStatus'];
-                  final planId =
-                      planIdStr != null ? int.tryParse(planIdStr) : null;
+                  final planIdStr = state.pathParameters['planId']!;
+                  final planId = int.parse(planIdStr);
+                  final title = state.pathParameters['title']!;
+
                   return NoTransitionPage(
-                    child: PlanCreateView(
+                    child: ArchivingRestartView(
                       planId: planId,
-                      planStatus: planStatus,
-                    ), // null 허용
+                      title: title,
+                    ),
                   );
                 },
               ),
               GoRoute(
-                  path: 'template/:templateName',
-                  name: PlanTeamplateView.routeName,
-                  pageBuilder: (context, state) {
-                    final templateName = state.pathParameters['templateName']!;
-                    return NoTransitionPage(
-                      child: PlanTeamplateView(
-                        templateName: templateName,
-                      ),
-                    );
-                  }),
-              GoRoute(
-                  path: 'templateDetail',
-                  name: PlanTemplateDetailView.routeName,
-                  pageBuilder: (context, state) {
-                    final templateDetail = state.extra as PlanTemplateDetail;
-                    return NoTransitionPage(
-                        child: PlanTemplateDetailView(
-                            templateDetai: templateDetail));
-                  }),
-              GoRoute(
-                path: 'archiving',
-                name: ArchivingView.routeName,
-                pageBuilder: (context, state) => NoTransitionPage(
-                  child: ArchivingView(),
-                ),
-                routes: [
-                  GoRoute(
-                      path: 'archivingDetail/:planId',
-                      name: ArchivingDetailView.routeName,
-                      pageBuilder: (context, state) {
-                        final planIdStr = state.pathParameters['planId']!;
-                        final planId = int.parse(planIdStr);
-                        return NoTransitionPage(
-                          child: ArchivingDetailView(
-                            planId: planId,
-                          ),
-                        );
-                      }),
-                  GoRoute(
-                    path: 'archivingRestart/:planId/:title',
-                    name: ArchivingRestartView.routeName,
-                    pageBuilder: (context, state) {
-                      final planIdStr = state.pathParameters['planId']!;
-                      final planId = int.parse(planIdStr);
-                      final title = state.pathParameters['title']!;
-
-                      return NoTransitionPage(
-                        child: ArchivingRestartView(
-                          planId: planId,
-                          title: title,
-                        ),
-                      );
-                    },
-                  ),
-                  GoRoute(
-                    path: 'archivingComplete/:icon/:title',
-                    name: ArchivingCompleteView.routeName,
-                    pageBuilder: (context, state) {
-                      final icon = state.pathParameters['icon']!;
-                      final title = state.pathParameters['title']!;
-                      return NoTransitionPage(
-                          child:
-                              ArchivingCompleteView(icon: icon, title: title));
-                    },
-                  ),
-                  GoRoute(
-                    path: 'archivingCompleteNavigator/:icon/:title',
-                    name: ArchivingCompleteNavigator.routeName,
-                    pageBuilder: (context, state) {
-                      final icon = state.pathParameters['icon']!;
-                      final title = state.pathParameters['title']!;
-                      return NoTransitionPage(
-                          child: ArchivingCompleteNavigator(
-                              icon: icon, title: title));
-                    },
-                  )
-                ],
+                path: 'archivingComplete/:icon/:title',
+                name: ArchivingCompleteView.routeName,
+                pageBuilder: (context, state) {
+                  final icon = state.pathParameters['icon']!;
+                  final title = state.pathParameters['title']!;
+                  return NoTransitionPage(
+                      child: ArchivingCompleteView(icon: icon, title: title));
+                },
               ),
+              GoRoute(
+                path: 'archivingCompleteNavigator/:icon/:title',
+                name: ArchivingCompleteNavigator.routeName,
+                pageBuilder: (context, state) {
+                  final icon = state.pathParameters['icon']!;
+                  final title = state.pathParameters['title']!;
+                  return NoTransitionPage(
+                      child:
+                          ArchivingCompleteNavigator(icon: icon, title: title));
+                },
+              )
             ],
-            //아카이빙
           ),
+          //아카이빙
           // 길티프리
           GoRoute(
             path: 'guilty-intro',

--- a/lib/ui/common/view/root_tab.dart
+++ b/lib/ui/common/view/root_tab.dart
@@ -45,6 +45,10 @@ class _RootTabState extends ConsumerState<RootTab>
     });
   }
 
+  void changeTap(int index) {
+    controller.animateTo(index);
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -121,7 +125,11 @@ class _RootTabState extends ConsumerState<RootTab>
         controller: controller,
         children: [
           PlanView(),
-          isGuiltyFree ? GuiltyFreeIngView() : MainView(),
+          isGuiltyFree
+              ? GuiltyFreeIngView()
+              : MainView(
+                  goToPlan: () => changeTap(0),
+                ),
           ArchivingView(),
         ],
       ),

--- a/lib/ui/main/component/main_top_widget.dart
+++ b/lib/ui/main/component/main_top_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
@@ -11,12 +13,13 @@ import '../../common/assets.dart';
 import '../../guilty_free/start/view/guilty_free_intro_view.dart';
 import '../const/main_enums.dart';
 
-class MainTopWidget extends StatelessWidget {
+class MainTopWidget extends StatefulWidget {
   final RouteType type;
   final TaskStatus status;
   final Future<void> onGuiltyFreePressed;
   final bool? canUseGuiltyFree;
   final int consecutiveDay;
+  final bool showAnimation;
 
   const MainTopWidget({
     super.key,
@@ -25,20 +28,89 @@ class MainTopWidget extends StatelessWidget {
     required this.onGuiltyFreePressed,
     required this.canUseGuiltyFree,
     required this.consecutiveDay,
+    required this.showAnimation,
   });
+
+  @override
+  State<MainTopWidget> createState() => _MainTopWidgetState();
+}
+
+class _MainTopWidgetState extends State<MainTopWidget>
+    with TickerProviderStateMixin {
+  late AnimationController _positionController;
+  late AnimationController _rotationController;
+  late Animation<double> _positionAnimation;
+  late Animation<double> _rotationAnimation;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _positionController = AnimationController(
+      duration: const Duration(seconds: 4),
+      vsync: this,
+    );
+
+    _rotationController = AnimationController(
+      duration: const Duration(seconds: 4),
+      vsync: this,
+    );
+
+    // 위치 애니메이션: left=20에서 시작해서 오른쪽 끝까지 갔다가 다시 left=20으로
+    _positionAnimation = Tween<double>(
+      begin: 0.0, // 0이면 left=20 위치
+      end: 1.0, // 1이면 오른쪽 끝까지
+    ).animate(CurvedAnimation(
+      parent: _positionController,
+      curve: Curves.linear,
+    ));
+
+    _rotationAnimation = Tween<double>(
+      begin: 0.0,
+      end: 8 * 3.14159, // 4바퀴 회전
+    ).animate(CurvedAnimation(
+      parent: _rotationController,
+      curve: Curves.linear,
+    ));
+
+    if (widget.showAnimation) {
+      _startAnimation();
+
+      // 20초 뒤에 재시작
+      _timer = Timer.periodic(
+        const Duration(seconds: 20),
+        (_) => _startAnimation(),
+      );
+    }
+  }
+
+  void _startAnimation() {
+    _positionController.reset();
+    _rotationController.reset();
+
+    _positionController.forward();
+    _rotationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _positionController.dispose();
+    _rotationController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     // 루트 타입과 태스크 달성 상태에 따라 보여줄 마스코트 이미지를 가져옵니다
     String asset = getAsset(
-      type: type,
-      status: status,
+      type: widget.type,
+      status: widget.status,
     );
 
     return Padding(
       padding: EdgeInsetsGeometry.only(
-        left: 20.0,
-        right: 20.0,
         top: 40.0,
       ),
       child: SizedBox(
@@ -54,13 +126,13 @@ class MainTopWidget extends StatelessWidget {
                 itemHeight: 90,
                 itemWidth: 200,
                 onChanged: (value) {},
-                maxValue: consecutiveDay + 1,
+                maxValue: widget.consecutiveDay + 1,
                 minValue: 0,
-                value: consecutiveDay,
+                value: widget.consecutiveDay,
                 selectedTextStyle: PlanitTypos.pretendardBlack90.copyWith(
-                  color: status == TaskStatus.nothing
+                  color: widget.status == TaskStatus.nothing
                       ? PlanitColors.white02
-                      : (status == TaskStatus.allPassionate
+                      : (widget.status == TaskStatus.allPassionate
                           ? PlanitColors.primary
                           : PlanitColors.black01),
                 ),
@@ -71,7 +143,7 @@ class MainTopWidget extends StatelessWidget {
             ),
             // 마이페이지 버튼
             Positioned(
-              left: 0.0,
+              left: 20.0,
               child: IconButton(
                 icon: SvgPicture.asset(Assets.profile),
                 onPressed: () => context.goNamed(MypageView.routeName),
@@ -80,15 +152,15 @@ class MainTopWidget extends StatelessWidget {
             ),
             // 길티프리 버튼
             Positioned(
-              right: 0.0,
+              right: 20.0,
               child: IconButton(
                 icon: SvgPicture.asset(Assets.guiltyFree),
                 onPressed: () async {
                   // 길티프리 가능한 상태인지 확인 후 랜딩
-                  await onGuiltyFreePressed;
-                  if (canUseGuiltyFree != null && context.mounted) {
+                  await widget.onGuiltyFreePressed;
+                  if (widget.canUseGuiltyFree != null && context.mounted) {
                     context.goNamed(
-                      canUseGuiltyFree!
+                      widget.canUseGuiltyFree!
                           ? GuiltyFreeIntroView.routeName
                           : GuiltyFreeBlockedView.routeName,
                     );
@@ -98,11 +170,57 @@ class MainTopWidget extends StatelessWidget {
               ),
             ),
             // 마스코트 에셋
-            Positioned(
-              left: 0.0,
-              bottom: 0.0,
-              child: SvgPicture.asset(asset),
-            ),
+            AnimatedBuilder(
+              animation: Listenable.merge(
+                [_positionAnimation, _rotationAnimation],
+              ),
+              builder: (context, child) {
+                // 화면 너비 계산 (MediaQuery 사용)
+                final screenWidth = MediaQuery.of(context).size.width;
+
+                // 위치 계산 로직
+                double leftPosition;
+
+                if (_positionAnimation.value <= 0.25) {
+                  // 첫 번째 단계: left=20에서 왼쪽 화면 밖으로 - 빠른 이동 (0~0.25)
+                  final progress = (_positionAnimation.value * 4); // 0 to 1
+                  final acceleratedProgress =
+                      (progress * 2).clamp(0.0, 1.0); // 2배 속도, 최대 1로 제한
+                  leftPosition = 20 - acceleratedProgress * 120; // 20 to -100
+                } else {
+                  // 두 번째 단계: 오른쪽 화면 밖에서 left=20까지 (0.25~1.0)
+                  final progress =
+                      (_positionAnimation.value - 0.25) / 0.75; // 0 to 1
+                  final startPosition = screenWidth + 100; // 오른쪽 화면 밖 시작점
+                  final endPosition = 20; // 목표 지점
+                  leftPosition = startPosition -
+                      progress *
+                          (startPosition - endPosition); // 오른쪽 밖에서 left=20까지
+                }
+
+                // 회전 각도 계산
+                double rotationAngle;
+                if (_positionAnimation.value <= 0.25) {
+                  // 첫 번째 단계: 회전수를 줄임 (예: 절반만 회전)
+                  rotationAngle =
+                      -_rotationAnimation.value * 0.5; // 회전 속도를 절반으로
+                } else {
+                  // 두 번째 단계: 정상 회전
+                  rotationAngle = -_rotationAnimation.value;
+                }
+
+                return Positioned(
+                  left: leftPosition,
+                  bottom: 0.0,
+                  child: Transform.rotate(
+                    angle: rotationAngle,
+                    child: SvgPicture.asset(
+                      asset, // SVG 파일 경로
+                    ),
+                  ),
+                );
+              },
+            )
           ],
         ),
       ),

--- a/lib/ui/main/component/plan_list_view.dart
+++ b/lib/ui/main/component/plan_list_view.dart
@@ -11,12 +11,14 @@ class PlanListView extends StatelessWidget {
   final List<TodayPlanModel> plans;
   final bool showRecoveryRoutineBanner;
   final OnCheckboxTap onCheckboxTap;
+  final VoidCallback goToPlan;
 
   const PlanListView({
     super.key,
     required this.plans,
     required this.showRecoveryRoutineBanner,
     required this.onCheckboxTap,
+    required this.goToPlan,
   });
 
   @override
@@ -40,12 +42,22 @@ class PlanListView extends StatelessWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
-                Text(
-                  '새 플랜 제작하기',
-                  style: PlanitTypos.caption.copyWith(
-                    color: PlanitColors.black03,
+                GestureDetector(
+                  onTap: goToPlan,
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 8.0),
+                    color: PlanitColors.transparent,
+                    child: Text(
+                      '새 플랜 제작하기',
+                      style: PlanitTypos.caption.copyWith(
+                        color: PlanitColors.black03,
+                        decoration: TextDecoration.underline,
+                        decorationColor: PlanitColors.black03,
+                        decorationThickness: 0.8,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
-                  textAlign: TextAlign.center,
                 ),
               ],
             ),

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -71,17 +71,23 @@ class MainView extends HookConsumerWidget {
       }
     });
 
+    bool showAnimation = state.taskStatus == TaskStatus.partial ||
+        state.taskStatus == TaskStatus.allPassionate;
+
     return DefaultLayout(
       child: Stack(
         children: [
           Column(
             children: [
               MainTopWidget(
+                // 값 변할 시 재빌드 될 수 있도록 key로 전달
+                key: ValueKey(showAnimation),
                 status: state.taskStatus,
                 type: state.routeType,
                 onGuiltyFreePressed: viewModel.checkCanUseGuiltyFree(),
                 canUseGuiltyFree: state.canUseGuiltyFree,
                 consecutiveDay: state.consecutiveDay,
+                showAnimation: showAnimation,
               ),
               RouteSwitchBanner(
                 type: state.routeType,

--- a/lib/ui/main/main_view.dart
+++ b/lib/ui/main/main_view.dart
@@ -20,7 +20,12 @@ import 'component/route_switch_banner.dart';
 class MainView extends HookConsumerWidget {
   static String get routeName => 'main';
 
-  const MainView({super.key});
+  final VoidCallback goToPlan;
+
+  const MainView({
+    super.key,
+    required this.goToPlan,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -93,6 +98,7 @@ class MainView extends HookConsumerWidget {
                     : state.plans.passionatePlans,
                 showRecoveryRoutineBanner: state.showRecoveryRoutineBanner,
                 onCheckboxTap: viewModel.onCheckboxTap,
+                goToPlan: () => goToPlan(),
               ),
             ],
           ),

--- a/lib/ui/mypage/view/mypage_account_view.dart
+++ b/lib/ui/mypage/view/mypage_account_view.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:planit/core/loading_status.dart';
+import 'package:planit/theme/planit_colors.dart';
+import 'package:planit/theme/planit_typos.dart';
+import 'package:planit/ui/common/comopnent/planit_bottom_sheet.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
 import 'package:planit/ui/common/comopnent/planit_loading.dart';
+import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
 import 'package:planit/ui/mypage/component/account_info_widget.dart';
@@ -54,7 +59,43 @@ class MypageAccountView extends HookConsumerWidget {
                     SizedBox(
                       width: double.infinity,
                       child: PlanitButton(
-                        onPressed: () => viewModel.withdraw(),
+                        onPressed: () {
+                          showModalBottomSheet(
+                            context: context,
+                            builder: (context) => PlanitBottomSheet(
+                              content: Padding(
+                                padding: EdgeInsetsGeometry.only(
+                                  top: 16.0,
+                                  bottom: 24.0,
+                                ),
+                                child: Column(
+                                  children: [
+                                    PlanitText(
+                                      '정말 회원 탈퇴를 진행할까요?',
+                                      style: PlanitTypos.title3.copyWith(
+                                        color: PlanitColors.red,
+                                      ),
+                                    ),
+                                    SizedBox(height: 16.0),
+                                    BottomSheetBtn(
+                                      label: '네, 진행할게요',
+                                      onTap: viewModel.withdraw,
+                                      labelColor: PlanitColors.red,
+                                    ),
+                                    Divider(
+                                      color: PlanitColors.white03,
+                                      height: 0.5,
+                                    ),
+                                    BottomSheetBtn(
+                                      label: '아니오',
+                                      onTap: context.pop,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          );
+                        },
                         buttonColor: PlanitButtonColor.red,
                         buttonSize: PlanitButtonSize.large,
                         label: '회원탈퇴',
@@ -70,6 +111,39 @@ class MypageAccountView extends HookConsumerWidget {
               child: PlanitLoading(),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class BottomSheetBtn extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color labelColor;
+
+  const BottomSheetBtn({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.labelColor = PlanitColors.black01,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        color: PlanitColors.transparent,
+        padding: EdgeInsets.symmetric(
+          horizontal: 20.0,
+          vertical: 16.0,
+        ),
+        child: PlanitText(
+          label,
+          style: PlanitTypos.body2.copyWith(
+            color: labelColor,
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/plan/component/template_detail_card.dart
+++ b/lib/ui/plan/component/template_detail_card.dart
@@ -22,7 +22,7 @@ class TemplateDetailCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: GestureDetector(
         onTap: () {
-          context.pushNamed(PlanTemplateDetailView.routeName,
+          context.goNamed(PlanTemplateDetailView.routeName,
               extra: templateDetail);
         },
         child: Container(

--- a/lib/ui/plan/plan_template/plan_template_detail_view.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:planit/theme/planit_colors.dart';
 import 'package:planit/theme/planit_typos.dart';
 import 'package:planit/ui/common/comopnent/planit_button.dart';
 import 'package:planit/ui/common/comopnent/planit_text.dart';
 import 'package:planit/ui/common/comopnent/planit_toast.dart';
 import 'package:planit/ui/common/const/planit_button_style.dart';
 import 'package:planit/ui/common/view/default_layout.dart';
-import 'package:planit/ui/common/view/root_tab.dart';
 import 'package:planit/ui/plan/component/task_card.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view_model.dart';

--- a/lib/ui/plan/plan_template/plan_template_detail_view.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view.dart
@@ -16,6 +16,7 @@ import 'package:planit/ui/plan/plan_template/plan_template_detail_view_model.dar
 class PlanTemplateDetailView extends HookConsumerWidget {
   static String get routeName => 'template_detail';
   final PlanTemplateDetail templateDetai;
+
   const PlanTemplateDetailView({required this.templateDetai, super.key});
 
   @override
@@ -23,14 +24,10 @@ class PlanTemplateDetailView extends HookConsumerWidget {
     final viewmodel = ref.read(planTemplateViewModelProvider.notifier);
 
     return DefaultLayout(
+      title: templateDetai.title,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          AppBar(
-            backgroundColor: PlanitColors.transparent,
-            title: PlanitText(templateDetai.title,
-                style: PlanitTypos.body2.copyWith(color: PlanitColors.black01)),
-          ),
           Padding(
             padding:
                 const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 32),
@@ -47,12 +44,15 @@ class PlanTemplateDetailView extends HookConsumerWidget {
             ),
           ),
           Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 20).copyWith(top: 40),
+            padding: const EdgeInsets.symmetric(horizontal: 20).copyWith(
+              top: 40,
+              bottom: 12,
+            ),
             child: PlanitText('미리보기', style: PlanitTypos.title3),
           ),
           ListView.builder(
             shrinkWrap: true,
+            padding: EdgeInsets.zero,
             itemCount: templateDetai.tasks.length,
             itemBuilder: (context, index) {
               return Padding(
@@ -61,6 +61,7 @@ class PlanTemplateDetailView extends HookConsumerWidget {
                     title: templateDetai.tasks[index].title,
                     taskType: templateDetai.tasks[index].taskType,
                     taskId: index,
+                    showMore: false,
                   ));
             },
           ),
@@ -71,22 +72,23 @@ class PlanTemplateDetailView extends HookConsumerWidget {
             child: SizedBox(
               width: double.infinity,
               child: PlanitButton(
-                  onPressed: () async {
-                    try {
-                      await viewmodel.createPlanAndAddTask(templateDetai);
-                      if (context.mounted) {
-                        context.pushNamed(RootTab.routeName);
-                      }
-                    } catch (e) {
-                      // 에러 처리 로직 추가
-                      PlanitToast(
-                        label: '플랜 만들기에 실패했습니다',
-                      );
+                onPressed: () async {
+                  try {
+                    await viewmodel.createPlanAndAddTask(templateDetai);
+                    if (context.mounted) {
+                      context.pop();
                     }
-                  },
-                  buttonColor: PlanitButtonColor.black,
-                  buttonSize: PlanitButtonSize.large,
-                  label: '이 템플릿으로 플랜 만들기'),
+                  } catch (e) {
+                    // 에러 처리 로직 추가
+                    PlanitToast(
+                      label: '플랜 만들기에 실패했습니다',
+                    );
+                  }
+                },
+                buttonColor: PlanitButtonColor.black,
+                buttonSize: PlanitButtonSize.large,
+                label: '이 템플릿으로 플랜 만들기',
+              ),
             ),
           )
         ],

--- a/lib/ui/plan/plan_template/plan_template_detail_view.dart
+++ b/lib/ui/plan/plan_template/plan_template_detail_view.dart
@@ -11,6 +11,8 @@ import 'package:planit/ui/plan/component/task_card.dart';
 import 'package:planit/ui/plan/plan_template/plan_template.dart';
 import 'package:planit/ui/plan/plan_template/plan_template_detail_view_model.dart';
 
+import '../plan_main/plan_view_model.dart';
+
 class PlanTemplateDetailView extends HookConsumerWidget {
   static String get routeName => 'template_detail';
   final PlanTemplateDetail templateDetai;
@@ -20,6 +22,7 @@ class PlanTemplateDetailView extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final viewmodel = ref.read(planTemplateViewModelProvider.notifier);
+    final PlanViewModel planViewModel = ref.read(planViewModelProvider.notifier);
 
     return DefaultLayout(
       title: templateDetai.title,
@@ -73,6 +76,7 @@ class PlanTemplateDetailView extends HookConsumerWidget {
                 onPressed: () async {
                   try {
                     await viewmodel.createPlanAndAddTask(templateDetai);
+                    planViewModel.init();
                     if (context.mounted) {
                       context.pop();
                     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "A new Flutter project."
 
 publish_to: 'none'
 
-version: 1.0.0+2
+version: 1.0.0+4
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 메인>마이페이지>회원탈퇴 시 재확인 바텀시트가 추가되었습니다
- 메인>오늘의 할 일 없는 경우 [새 플랜 제작하기]를 클릭하면 NavBar에서 플랜을 선택한 효과가 나타납니다 (플랜으로 이동)
- 태스크 달성한 경우 마스코트가 굴러다니기 시작합니다
   - 화면을 유지하는 경우 20초에 한 바퀴 구릅니다
   - 화면을 나갔다 들어와도 한 바퀴 굴러줍니다

https://github.com/user-attachments/assets/5b574e8f-153e-455d-be91-2479d31bc722
https://github.com/user-attachments/assets/438e8eca-2dba-4fff-83c9-ca6837ad5ce0

- 플랜 관련해서 Go-router 설정 조금 수정했어요
- 플랜은 RootTab에 포함되는 화면이어서, RootTap에 PlanView로 또 스택을 쌓으면 어색해집니다..! 제거했어요
- 템플릿 디테일 뷰 UI를 조금 수정하였고, 템플릿 생성 완료 시 플랜화면으로 pop 되도록(기존에는 홈으로 됐음..), 플랜화면 자동으로 새로고침 되도록 했습니다

https://github.com/user-attachments/assets/98471632-3c4a-42b5-a69d-c9caed488f47


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 템플릿 쪽은 안 건들고 계신 거 같아서 조금 수정했어요..! 양해 부탁드립니다
- 뭔가 이것저것 이슈 많이 드렸는데 이것까지 추가해서 해달라하기 좀 그래서ㅠㅠ 제가 호다닥 고쳤습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메인 상단 마스코트 애니메이션 추가(상태에 따라 자동 재생).
  * 메인에서 플랜 탭으로 즉시 이동 가능한 콜백/액션 추가.
  * 플랜 없음 상태의 “새 플랜 제작하기”를 탭해 바로 이동 가능.
  * 회원탈퇴 전 확인 바텀시트로 안전한 진행 유도.

* **Refactor**
  * 플랜·보관(route) 구조 전면 재정비: 플랜 관련 경로 평탄화 및 개별화로 네비게이션 정리.
  * 템플릿 상세 진입 방식 및 레이아웃(타이틀 표시, padding, 더보기 숨김) 정리; 진입 방식이 화면 대체로 변경.

* **Chores**
  * 앱 버전 업데이트: 1.0.0+4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->